### PR TITLE
Align workspace catalog with Phase 1 requirements - update lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,24 @@ catalogs:
     '@axe-core/react':
       specifier: ^4.7.3
       version: 4.11.0
+    '@storybook/addon-a11y':
+      specifier: ^8.3.5
+      version: 8.6.14
+    '@storybook/addon-docs':
+      specifier: ^8.3.5
+      version: 8.6.14
+    '@storybook/addon-essentials':
+      specifier: ^8.3.5
+      version: 8.6.14
+    '@storybook/react-vite':
+      specifier: ^8.3.5
+      version: 8.6.14
+    '@storybook/test':
+      specifier: ^8.3.5
+      version: 8.6.14
+    '@storybook/test-runner':
+      specifier: ^8.3.5
+      version: 8.6.14
     '@testing-library/jest-dom':
       specifier: ^6.6.3
       version: 6.9.1
@@ -18,18 +36,42 @@ catalogs:
     '@testing-library/user-event':
       specifier: ^14.5.2
       version: 14.6.1
+    '@types/react':
+      specifier: ^18.3.12
+      version: 18.3.26
+    '@types/react-dom':
+      specifier: ^18.3.1
+      version: 18.3.7
     '@vitejs/plugin-react':
       specifier: ^4.3.3
       version: 4.7.0
     eslint:
       specifier: ^9.15.0
       version: 9.38.0
+    eslint-config-prettier:
+      specifier: ^9.1.0
+      version: 9.1.2
+    eslint-plugin-react:
+      specifier: ^7.36.1
+      version: 7.37.5
+    chromatic:
+      specifier: ^11.12.6
+      version: 11.29.0
     jsdom:
       specifier: ^25.0.1
       version: 25.0.1
     prettier:
       specifier: ^3.3.3
       version: 3.6.2
+    storybook:
+      specifier: ^8.3.5
+      version: 8.6.14
+    tsd:
+      specifier: ^0.30.7
+      version: 0.30.7
+    typescript:
+      specifier: ^5.6.3
+      version: 5.9.3
     tsup:
       specifier: ^8.3.5
       version: 8.5.0
@@ -53,73 +95,73 @@ importers:
   .:
     devDependencies:
       '@axe-core/react':
-        specifier: ^4.7.3
+        specifier: 'catalog:'
         version: 4.11.0
       '@storybook/addon-a11y':
-        specifier: ^8.2.0
+        specifier: 'catalog:'
         version: 8.6.14(storybook@8.6.14(prettier@3.6.2))
       '@storybook/addon-docs':
-        specifier: ^8.2.0
+        specifier: 'catalog:'
         version: 8.6.14(@types/react@18.3.26)(storybook@8.6.14(prettier@3.6.2))
       '@storybook/addon-essentials':
-        specifier: ^8.2.0
+        specifier: 'catalog:'
         version: 8.6.14(@types/react@18.3.26)(storybook@8.6.14(prettier@3.6.2))
       '@storybook/react-vite':
-        specifier: ^8.2.0
+        specifier: 'catalog:'
         version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.52.5)(storybook@8.6.14(prettier@3.6.2))(typescript@5.9.3)(vite@5.4.21)
       '@testing-library/jest-dom':
-        specifier: ^6.5.0
+        specifier: 'catalog:'
         version: 6.9.1
       '@testing-library/react':
-        specifier: ^16.0.0
+        specifier: 'catalog:'
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@testing-library/user-event':
-        specifier: ^14.5.2
+        specifier: 'catalog:'
         version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/react':
-        specifier: ^18.3.12
+        specifier: 'catalog:'
         version: 18.3.26
       '@types/react-dom':
-        specifier: ^18.3.1
+        specifier: 'catalog:'
         version: 18.3.7(@types/react@18.3.26)
       '@vitejs/plugin-react':
-        specifier: ^4.3.1
+        specifier: 'catalog:'
         version: 4.7.0(vite@5.4.21)
       chromatic:
-        specifier: ^11.10.5
+        specifier: 'catalog:'
         version: 11.29.0
       eslint:
-        specifier: ^9.11.0
+        specifier: 'catalog:'
         version: 9.38.0
       eslint-config-prettier:
-        specifier: ^9.1.0
+        specifier: 'catalog:'
         version: 9.1.2(eslint@9.38.0)
       eslint-plugin-react:
-        specifier: ^7.36.1
+        specifier: 'catalog:'
         version: 7.37.5(eslint@9.38.0)
       jsdom:
-        specifier: ^25.0.0
+        specifier: 'catalog:'
         version: 25.0.1
       prettier:
-        specifier: ^3.3.3
+        specifier: 'catalog:'
         version: 3.6.2
       storybook:
-        specifier: ^8.2.0
+        specifier: 'catalog:'
         version: 8.6.14(prettier@3.6.2)
       tsd:
-        specifier: ^0.30.7
+        specifier: 'catalog:'
         version: 0.30.7
       tsup:
-        specifier: ^8.2.4
+        specifier: 'catalog:'
         version: 8.5.0(postcss@8.5.6)(typescript@5.9.3)
       typescript:
-        specifier: ^5.6.3
+        specifier: 'catalog:'
         version: 5.9.3
       vitest:
-        specifier: ^2.1.3
+        specifier: 'catalog:'
         version: 2.1.9(jsdom@25.0.1)
       vitest-axe:
-        specifier: 0.1.0
+        specifier: 'catalog:'
         version: 0.1.0(vitest@2.1.9(jsdom@25.0.1))
 
   packages/core:
@@ -147,10 +189,10 @@ importers:
         specifier: 'catalog:'
         version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/react':
-        specifier: ^18.3.12
+        specifier: 'catalog:'
         version: 18.3.26
       '@types/react-dom':
-        specifier: ^18.3.1
+        specifier: 'catalog:'
         version: 18.3.7(@types/react@18.3.26)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
@@ -165,13 +207,13 @@ importers:
         specifier: 'catalog:'
         version: 3.6.2
       tsd:
-        specifier: ^0.30.7
+        specifier: 'catalog:'
         version: 0.30.7
       tsup:
         specifier: 'catalog:'
         version: 8.5.0(postcss@8.5.6)(typescript@5.9.3)
       typescript:
-        specifier: ^5.6.3
+        specifier: 'catalog:'
         version: 5.9.3
       vite:
         specifier: 'catalog:'


### PR DESCRIPTION
## Summary
- update pnpm-lock.yaml so catalog-managed dependencies in the root importer use `catalog:` specifiers
- record catalog entries for the shared Storybook, linting, and tooling versions that back the workspace manifests

## Testing
- `pnpm install --no-frozen-lockfile` *(fails: 403 fetching @storybook/addon-essentials)*

------
https://chatgpt.com/codex/tasks/task_e_68fbf42e105883248e2c11dba0dd0bb6