### PR TITLE
fix: guard override rules spread

### DIFF
--- a/tools/eslint-config/src/index.ts
+++ b/tools/eslint-config/src/index.ts
@@ -35,7 +35,10 @@ export function withOverrides(overrides: Linter.Config): Linter.Config {
   return {
     ...baseEslintConfig,
     ...overrides,
-    rules: { ...baseEslintConfig.rules, ...overrides.rules }
+    rules: {
+      ...(baseEslintConfig.rules ?? {}),
+      ...(overrides.rules ?? {})
+    }
   };
 }
 


### PR DESCRIPTION
## Summary
- guard against missing override rules when merging eslint config overrides

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fbf431a38483249e350963871548be