### PR TITLE
Fix DynTabs to match updated arrow navigation hook API

### DIFF
--- a/src/ui/dyn-tabs.tsx
+++ b/src/ui/dyn-tabs.tsx
@@ -1,7 +1,6 @@
 import React, {
   forwardRef,
   useCallback,
-  useEffect,
   useId,
   useImperativeHandle,
   useMemo,
@@ -40,7 +39,7 @@ export const DynTabs = forwardRef<DynTabsRef, DynTabsProps>(
     ref
   ) => {
     const rootRef = useRef<HTMLDivElement>(null);
-    const { containerRef, setupNavigation } = useArrowNavigation({
+    const { containerRef, focusFirst, focusLast, focusAtIndex } = useArrowNavigation({
       orientation,
       selector: '[role="tab"]:not([aria-disabled="true"])'
     });
@@ -66,13 +65,6 @@ export const DynTabs = forwardRef<DynTabsRef, DynTabsProps>(
     const [activeTab, setActiveTab] = useState<string>(
       () => value ?? defaultValue ?? firstAvailableValue
     );
-
-    useEffect(() => {
-      const cleanup = setupNavigation?.();
-      return () => {
-        cleanup?.();
-      };
-    }, [setupNavigation]);
 
     const handleTabChange = useCallback(
       (tabValue: string) => {
@@ -105,38 +97,37 @@ export const DynTabs = forwardRef<DynTabsRef, DynTabsProps>(
     const focusTabByValue = useCallback(
       (tabValue: string) => {
         const tabs = focusableTabs();
-        const target = tabs.find(tab => tab.dataset.value === tabValue);
-        target?.focus();
+        const targetIndex = tabs.findIndex(tab => tab.dataset.value === tabValue);
+        if (targetIndex >= 0) {
+          focusAtIndex(targetIndex);
+        }
       },
-      [focusableTabs]
+      [focusAtIndex, focusableTabs]
     );
 
     const focusFirstTab = useCallback(() => {
-      const tabs = focusableTabs();
-      tabs[0]?.focus();
-    }, [focusableTabs]);
+      focusFirst();
+    }, [focusFirst]);
 
     const focusLastTab = useCallback(() => {
-      const tabs = focusableTabs();
-      tabs[tabs.length - 1]?.focus();
-    }, [focusableTabs]);
+      focusLast();
+    }, [focusLast]);
 
     const focusNextTab = useCallback(() => {
       const tabs = focusableTabs();
       const currentIndex = tabs.findIndex(tab => tab === document.activeElement);
       if (tabs.length === 0) return;
-      const nextIndex = currentIndex >= 0 ? (currentIndex + 1) % tabs.length : 0;
-      tabs[nextIndex]?.focus();
-    }, [focusableTabs]);
+      const nextIndex = currentIndex >= 0 ? currentIndex + 1 : 0;
+      focusAtIndex(nextIndex);
+    }, [focusAtIndex, focusableTabs]);
 
     const focusPreviousTab = useCallback(() => {
       const tabs = focusableTabs();
       const currentIndex = tabs.findIndex(tab => tab === document.activeElement);
       if (tabs.length === 0) return;
-      const previousIndex =
-        currentIndex > 0 ? currentIndex - 1 : tabs.length - 1;
-      tabs[previousIndex]?.focus();
-    }, [focusableTabs]);
+      const previousIndex = currentIndex > 0 ? currentIndex - 1 : tabs.length - 1;
+      focusAtIndex(previousIndex);
+    }, [focusAtIndex, focusableTabs]);
 
     useImperativeHandle(
       ref,


### PR DESCRIPTION
## Summary
- update DynTabs to consume the focus helper API from `useArrowNavigation`
- remove the obsolete `setupNavigation` effect now that the hook manages listeners

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fbf8f238188324a9c56ac7918b1504