### PR TITLE
Rename Turbo pipeline key to tasks

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-  "pipeline": {
+  "tasks": {
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "build/**", "storybook-static/**"],


### PR DESCRIPTION
## Summary
- rename the top-level key in `turbo.json` from `pipeline` to `tasks` to satisfy the latest Turbo config requirements

## Testing
- pnpm build *(fails: turbo not found because dependencies are not installed in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fc0c385ba083249db4de6d45525d46