### PR TITLE
fix: restore dyn tab item alias usage

### DIFF
--- a/src/types/components/dyn-tabs.types.ts
+++ b/src/types/components/dyn-tabs.types.ts
@@ -32,14 +32,14 @@ export interface DynTabsProps {
   children?: React.ReactNode;
   className?: string;
   onChange?: (value: string) => void;
-  items?: TabItem[];
+  items?: DynTabItem[];
   'aria-label'?: string;
   'aria-labelledby'?: string;
   'data-testid'?: string;
 }
 
 export interface DynTabProps {
-  item: TabItem;
+  item: DynTabItem;
   children?: React.ReactNode;
   isActive?: boolean;
   onSelect?: (value: string) => void;
@@ -52,7 +52,7 @@ export interface DynTabProps {
 }
 
 export interface DynTabPanelProps {
-  item: TabItem;
+  item: DynTabItem;
   children?: React.ReactNode;
   isActive?: boolean;
   className?: string;


### PR DESCRIPTION
## Summary
- restore DynTabItem usage in DynTabs types so the legacy alias remains consumable

## Testing
- pnpm exec tsd *(fails: Command "tsd" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fbf6631abc832492af9666b260b8cb