### PR TITLE
fix: remove duplicate sanitizeTokenKey

### DIFF
--- a/packages/design-tokens/build/generate-css-vars.ts
+++ b/packages/design-tokens/build/generate-css-vars.ts
@@ -9,10 +9,6 @@ function sanitizeTokenKey(key: string): string {
   return key.replace(/[^a-zA-Z0-9_-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '')
 }
 
-function sanitizeTokenKey(key: string): string {
-  return key.replace(/[^a-zA-Z0-9_-]/g, '-')
-}
-
 function toCSSVars(record: TokenRecord, prefix: string[] = []): string[] {
   return Object.entries(record).flatMap(([key, value]) => {
     const sanitizedKey = sanitizeTokenKey(key)


### PR DESCRIPTION
## Summary
- remove the duplicate sanitizeTokenKey definition in generate-css-vars
- retain the original normalization logic for token keys to avoid regressions

## Testing
- pnpm --filter design-tokens build *(fails: TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /workspace/dynui-fixed/tools/build-config/tsup.library.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68fc0fbec108832494985a200a9895d0