### PR TITLE
Fix duplicate sanitizeTokenKey implementation

### DIFF
--- a/packages/design-tokens/build/generate-css-vars.ts
+++ b/packages/design-tokens/build/generate-css-vars.ts
@@ -9,10 +9,6 @@ function sanitizeTokenKey(key: string): string {
   return key.replace(/[^a-zA-Z0-9_-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '')
 }
 
-function sanitizeTokenKey(key: string): string {
-  return key.replace(/[^a-zA-Z0-9_-]/g, '-')
-}
-
 function toCSSVars(record: TokenRecord, prefix: string[] = []): string[] {
   return Object.entries(record).flatMap(([key, value]) => {
     const sanitizedKey = sanitizeTokenKey(key)


### PR DESCRIPTION
## Summary
- remove the second sanitizeTokenKey definition so the build script has a single implementation

## Testing
- pnpm --filter design-tokens build *(fails: tsup config cannot load due to unknown .ts extension)*

------
https://chatgpt.com/codex/tasks/task_e_68fc0fbdde6c8324b9039648cf5642c2