### PR TITLE
Fix Turbo config to support Turbo v2 tasks layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
     "tools/*"
   ],
   "scripts": {
-    "build": "turbo build",
-    "dev": "turbo dev",
-    "test": "turbo test",
-    "test:a11y": "turbo test:a11y",
-    "typecheck": "turbo typecheck",
-    "lint": "turbo lint",
+    "build": "turbo --root-turbo-json turbo.root.json build",
+    "dev": "turbo --root-turbo-json turbo.root.json dev",
+    "test": "turbo --root-turbo-json turbo.root.json test",
+    "test:a11y": "turbo --root-turbo-json turbo.root.json test:a11y",
+    "typecheck": "turbo --root-turbo-json turbo.root.json typecheck",
+    "lint": "turbo --root-turbo-json turbo.root.json lint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "clean": "turbo clean",
+    "clean": "turbo --root-turbo-json turbo.root.json clean",
     "storybook": "cd apps/storybook && pnpm storybook",
     "build:storybook": "cd apps/storybook && pnpm build:storybook",
     "playground": "pnpm --filter playground dev"

--- a/turbo.json
+++ b/turbo.json
@@ -1,40 +1,4 @@
 {
-  "tasks": {
-    "build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**", "build/**", "storybook-static/**"],
-      "inputs": ["src/**/*.ts", "src/**/*.tsx", "package.json", "tsconfig*.json"]
-    },
-    "dev": {
-      "cache": false,
-      "persistent": true
-    },
-    "test": {
-      "dependsOn": ["build"],
-      "inputs": ["src/**/*.ts", "src/**/*.tsx", "tests/**/*.ts", "tests/**/*.tsx"],
-      "outputs": ["coverage/**"]
-    },
-    "test:a11y": {
-      "dependsOn": ["build"],
-      "inputs": ["src/**/*.ts", "src/**/*.tsx", "tests/**/*.ts", "tests/**/*.tsx"]
-    },
-    "lint": {
-      "inputs": ["src/**/*.ts", "src/**/*.tsx", "*.json", "*.js", "*.ts"]
-    },
-    "typecheck": {
-      "dependsOn": ["^build"],
-      "inputs": ["src/**/*.ts", "src/**/*.tsx", "tsconfig*.json"]
-    },
-    "clean": {
-      "cache": false
-    },
-    "storybook": {
-      "cache": false,
-      "persistent": true
-    },
-    "build:storybook": {
-      "dependsOn": ["^build"],
-      "outputs": ["storybook-static/**"]
-    }
-  }
+  "extends": ["//"],
+  "tasks": {}
 }

--- a/turbo.root.json
+++ b/turbo.root.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "build/**", "storybook-static/**"],
+      "inputs": ["src/**/*.ts", "src/**/*.tsx", "package.json", "tsconfig*.json"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "test": {
+      "dependsOn": ["build"],
+      "inputs": ["src/**/*.ts", "src/**/*.tsx", "tests/**/*.ts", "tests/**/*.tsx"],
+      "outputs": ["coverage/**"]
+    },
+    "test:a11y": {
+      "dependsOn": ["build"],
+      "inputs": ["src/**/*.ts", "src/**/*.tsx", "tests/**/*.ts", "tests/**/*.tsx"]
+    },
+    "lint": {
+      "inputs": ["src/**/*.ts", "src/**/*.tsx", "*.json", "*.js", "*.ts"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**/*.ts", "src/**/*.tsx", "tsconfig*.json"]
+    },
+    "clean": {
+      "cache": false
+    },
+    "storybook": {
+      "cache": false,
+      "persistent": true
+    },
+    "build:storybook": {
+      "dependsOn": ["^build"],
+      "outputs": ["storybook-static/**"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a workspace-level `turbo.json` that extends the root configuration to satisfy Turbo v2 validation
- move the existing task graph into `turbo.root.json` and update package scripts to point Turbo at the renamed file

## Testing
- pnpm build *(fails: TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for tools/build-config/tsup.library.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68fc0b5401a483249a097637eb9f5b1b