### PR TITLE
Fix Turbo root configuration after review feedback

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,4 +1,41 @@
 {
-  "extends": ["//"],
-  "tasks": {}
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "build/**", "storybook-static/**"],
+      "inputs": ["src/**/*.ts", "src/**/*.tsx", "package.json", "tsconfig*.json"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "test": {
+      "dependsOn": ["build"],
+      "inputs": ["src/**/*.ts", "src/**/*.tsx", "tests/**/*.ts", "tests/**/*.tsx"],
+      "outputs": ["coverage/**"]
+    },
+    "test:a11y": {
+      "dependsOn": ["build"],
+      "inputs": ["src/**/*.ts", "src/**/*.tsx", "tests/**/*.ts", "tests/**/*.tsx"]
+    },
+    "lint": {
+      "inputs": ["src/**/*.ts", "src/**/*.tsx", "*.json", "*.js", "*.ts"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**/*.ts", "src/**/*.tsx", "tsconfig*.json"]
+    },
+    "clean": {
+      "cache": false
+    },
+    "storybook": {
+      "cache": false,
+      "persistent": true
+    },
+    "build:storybook": {
+      "dependsOn": ["^build"],
+      "outputs": ["storybook-static/**"]
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- restore the workspace root `turbo.json` to host the pipeline definitions so the file parses without relying on an unsupported `extends`

## Testing
- pnpm turbo lint --dry-run *(fails: Invalid turbo.json configuration: No "extends" key found.)*

------
https://chatgpt.com/codex/tasks/task_e_68fc16f4883483249b09b7d1ed2ee90b