### PR TITLE
Restore root turbo.json extends pointer

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": ["//"],
-  "tasks": {}
+  "extends": ["./turbo.root.json"]
 }


### PR DESCRIPTION
## Summary
- update the workspace root turbo.json to extend the shared turbo.root.json configuration instead of inlining task definitions

## Testing
- pnpm turbo lint --dry-run --root-turbo-json turbo.root.json

------
https://chatgpt.com/codex/tasks/task_e_68fc1947ecf883248a57104224e8e73a