### PR TITLE
fix: Windows compatibility for turbo build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
     "tools/*"
   ],
   "scripts": {
-    "build": "./tools/run-turbo-task.js --root-turbo-json turbo.root.json build",
-    "dev": "./tools/run-turbo-task.js --root-turbo-json turbo.root.json dev",
-    "test": "./tools/run-turbo-task.js --root-turbo-json turbo.root.json test",
-    "test:a11y": "./tools/run-turbo-task.js --root-turbo-json turbo.root.json test:a11y",
-    "typecheck": "./tools/run-turbo-task.js --root-turbo-json turbo.root.json typecheck",
-    "lint": "./tools/run-turbo-task.js --root-turbo-json turbo.root.json lint",
+    "build": "node ./tools/run-turbo-task.js --root-turbo-json turbo.root.json build",
+    "dev": "node ./tools/run-turbo-task.js --root-turbo-json turbo.root.json dev",
+    "test": "node ./tools/run-turbo-task.js --root-turbo-json turbo.root.json test",
+    "test:a11y": "node ./tools/run-turbo-task.js --root-turbo-json turbo.root.json test:a11y",
+    "typecheck": "node ./tools/run-turbo-task.js --root-turbo-json turbo.root.json typecheck",
+    "lint": "node ./tools/run-turbo-task.js --root-turbo-json turbo.root.json lint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "clean": "./tools/run-turbo-task.js --root-turbo-json turbo.root.json clean",
+    "clean": "node ./tools/run-turbo-task.js --root-turbo-json turbo.root.json clean",
     "storybook": "cd apps/storybook && pnpm storybook",
     "build:storybook": "cd apps/storybook && pnpm build:storybook",
     "playground": "pnpm --filter playground dev"


### PR DESCRIPTION
## Problem

The build process was failing on Windows with the error:
```
'.' is not recognized as an internal or external command,
operable program or batch file.
```

This happened because Windows doesn't recognize shebang lines (`#!/usr/bin/env node`) in scripts and couldn't execute `./tools/run-turbo-task.js` directly.

## Solution

Added explicit `node` prefix to all turbo task runner scripts in `package.json`:
- `./tools/run-turbo-task.js` → `node ./tools/run-turbo-task.js`

This ensures cross-platform compatibility by explicitly invoking Node.js to run the script.

## Changes

- ✅ Updated all turbo-related scripts in `package.json` to use `node` prefix
- ✅ Maintains compatibility with Unix systems (shebang still works as fallback)
- ✅ Scripts affected: `build`, `dev`, `test`, `test:a11y`, `typecheck`, `lint`, `clean`

## Testing

After this fix, the following commands should work on Windows:
```bash
pnpm build
pnpm dev
pnpm test
pnpm lint
```