### PR TITLE
docs(core): add README documenting stub types and barrel wiring pattern

### DIFF
--- a/packages/core/src/types/components/README.md
+++ b/packages/core/src/types/components/README.md
@@ -1,0 +1,25 @@
+# DynUI Core Types – Stub Pattern
+
+This package uses a temporary stub pattern to keep the TypeScript public API stable while components are being implemented.
+
+## Why stubs?
+
+When some component types are not yet implemented, the DTS build may fail with TS2307 errors. To avoid blocking builds and allow incremental delivery, we provide a central file that declares placeholder types.
+
+## Files
+
+- `packages/core/src/types/components/dyn-stubs.types.ts`
+  - Exports placeholder `unknown`-based types for all not-yet-implemented components.
+- `packages/core/src/types/components/index.ts`
+  - Re-exports `./dyn-stubs.types` first, then re-exports any real `./dyn-*.types` modules when they are available.
+
+## Workflow
+
+1. Add a new component? Add its public type name to `dyn-stubs.types.ts` first.
+2. Implement the real type(s) in a dedicated file (e.g. `./dyn-avatar.types.ts`).
+3. Update imports/exports to use the real type and remove the corresponding placeholder from `dyn-stubs.types.ts`.
+
+## Notes
+
+- Runtime JS/CJS output is unaffected by these types – this pattern only affects DTS generation.
+- This pattern should be removed once all referenced component types have real definitions.


### PR DESCRIPTION
## Document stub types pattern for `@dynui/core` DTS stability

This PR adds documentation that explains the current stub types approach used to prevent DTS build failures while some component types are not yet implemented.

### What’s included
- `packages/core/src/types/components/README.md`
  - Explains why stubs are needed
  - Details the files involved: `dyn-stubs.types.ts` and the `index.ts` barrel
  - Describes the workflow for gradually replacing stubs with real type definitions

### Why this change
The core package DTS build previously failed with TS2307 due to referenced `./dyn-*.types` files not yet existing. The stub-based approach is now implemented to keep the API stable and unblock builds; this README creates an audit trail and guidance for contributors.

### Non-goals
- No changes to runtime logic or build config
- No changes to existing type files beyond documentation

### How to validate
- Read the README and follow the steps to add a new component type safely
- Ensure DTS continues to compile successfully for `@dynui/core`
