### PR TITLE
Fix DynTabs aria-label typing regression

### DIFF
--- a/packages/core/src/types/components/dyn-tabs.types.ts
+++ b/packages/core/src/types/components/dyn-tabs.types.ts
@@ -35,6 +35,8 @@ export interface DynTabsProps {
   'data-testid'?: string
   /** Additional CSS class */
   className?: string
+  /** Accessible name for the tabs container */
+  'aria-label'?: string
   /** Arbitrary props passthrough */
   [key: string]: unknown
 }


### PR DESCRIPTION
## Summary
- restore an explicit `'aria-label'` prop on `DynTabsProps`
- keep the forwarded attribute typed for the component root element

## Testing
- not run (type-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fcf96ee9648324abbbe1a9e0851a11