### PR TITLE
Handle optional disabled prop when cloning DynTab

### DIFF
--- a/src/ui/dyn-tabs.tsx
+++ b/src/ui/dyn-tabs.tsx
@@ -175,12 +175,15 @@ export const DynTabs = forwardRef<DynTabsRef, DynTabsProps>(
               const item = child.props.item;
               if (!item) return null;
               const { tabId, panelId } = getItemIdentifiers(item);
+              const disabledProps =
+                item.disabled !== undefined ? { disabled: item.disabled } : {};
+
               return React.cloneElement(child, {
                 ...child.props,
+                ...disabledProps,
                 tabId,
                 panelId,
                 isActive: item.value === currentTab,
-                disabled: item.disabled,
                 activation,
                 onSelect: handleTabChange,
                 onFocusTab: handleTabFocus


### PR DESCRIPTION
## Summary
- ensure disabled state is only passed to DynTab when defined to satisfy strict optional property checks
- preserve existing behavior by letting the DynTab component default the disabled prop when unspecified

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fd345b68dc8324a8ced9ef836f2386