### PR TITLE
fix: remove unused RefObject import from dyn-tabs types

### DIFF
--- a/src/types/components/dyn-tabs.types.ts
+++ b/src/types/components/dyn-tabs.types.ts
@@ -1,4 +1,4 @@
-import type { ReactNode, RefObject } from 'react';
+import type { ReactNode } from 'react';
 
 export interface TabItem {
   value: string;


### PR DESCRIPTION
## Summary
- drop the unused RefObject import in dyn-tabs type definitions to satisfy noUnusedLocals

## Testing
- pnpm typecheck *(fails: existing type errors across @dynui/core unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68fd384a539c83248d8ad49ff8129bcb