### PR TITLE
Improve DynTabs typings and event handling

### DIFF
--- a/packages/core/src/types/components/dyn-stubs.types.ts
+++ b/packages/core/src/types/components/dyn-stubs.types.ts
@@ -1,4 +1,11 @@
-import type { ReactNode, ChangeEvent, FocusEvent, MouseEvent } from 'react'
+import type {
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  ReactNode,
+  ChangeEvent,
+  FocusEvent,
+  MouseEvent
+} from 'react'
 
 export interface DynCheckboxProps {
   id?: string
@@ -54,23 +61,24 @@ export interface DynRadioGroupProps {
 
 export type DynStepperProps = Record<string, unknown>
 
-export interface DynMenuProps {
+export interface DynMenuProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
   orientation?: 'horizontal' | 'vertical'
   onAction?: (key: string) => void
   children?: ReactNode
   className?: string
   'data-testid'?: string
-  [key: string]: unknown
 }
 
-export interface DynMenuItemProps {
+export interface DynMenuItemProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children' | 'onClick'> {
   action?: string
   onAction?: (key: string) => void
   children?: ReactNode
   disabled?: boolean
   className?: string
   'data-testid'?: string
-  [key: string]: unknown
+  onClick?: ButtonHTMLAttributes<HTMLButtonElement>['onClick']
 }
 
 export interface DynBreadcrumbProps {
@@ -100,7 +108,8 @@ export interface DynListViewItem {
   disabled?: boolean
 }
 
-export interface DynListViewProps {
+export interface DynListViewProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
   items?: DynListViewItem[]
   selectedItem?: string
   onSelectionChange?: (selected: string[]) => void
@@ -109,7 +118,6 @@ export interface DynListViewProps {
   className?: string
   'aria-multiselectable'?: boolean
   'data-testid'?: string
-  [key: string]: unknown
 }
 
 export interface DynAvatarProps {

--- a/packages/core/src/types/components/dyn-tabs.types.ts
+++ b/packages/core/src/types/components/dyn-tabs.types.ts
@@ -1,97 +1,78 @@
-import type { ReactNode } from 'react'
+import type {
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  ReactNode
+} from 'react'
 
-/**
- * Individual tab item interface
- */
 export interface TabItem {
-  /** Unique key for React rendering */
-  key: string
-  /** Value used for selection state */
   value: string
-  /** Display label for the tab */
-  label: string
-  /** Whether tab is disabled */
+  label?: ReactNode
+  panel?: ReactNode
   disabled?: boolean
-}
-
-/**
- * Props for DynTabs container component
- * Manages tab selection state and keyboard navigation
- */
-export interface DynTabsProps {
-  /** Currently selected tab value (controlled) */
-  value?: string
-  /** Default selected tab value (uncontrolled) */
-  defaultValue?: string
-  /** Called when selected tab changes */
-  onChange?: (value: string) => void
-  /** Tab orientation */
-  orientation?: 'horizontal' | 'vertical'
-  /** Activation behavior (auto activates on focus, manual requires Enter/Space) */
-  activation?: 'auto' | 'manual'
-  /** Tab and panel children */
-  children?: ReactNode
-  /** Test identifier */
-  'data-testid'?: string
-  /** Additional CSS class */
+  tabId?: string
+  panelId?: string
   className?: string
-  /** Accessible name for the tabs container */
+  key?: string
+  'aria-controls'?: string
   'aria-label'?: string
-  /** Arbitrary props passthrough */
-  [key: string]: unknown
+  'aria-labelledby'?: string
 }
 
-/**
- * Props for individual DynTab component
- */
-export interface DynTabProps {
-  /** Tab item configuration */
-  item: TabItem
-  /** Whether tab is disabled */
-  disabled?: boolean
-  /** Whether the tab is currently active */
-  isActive?: boolean
-  /** Called when tab should become active */
-  onSelect?: (value: string) => void
-  /** Activation behavior override */
-  activation?: 'auto' | 'manual'
-  /** Additional CSS class */
-  className?: string
-  /** Tab contents */
-  children?: ReactNode
-  /** Arbitrary props passthrough */
-  [key: string]: unknown
-}
+export type DynTabItem = TabItem
 
-/**
- * Props for DynTabPanel component
- */
-export interface DynTabPanelProps {
-  /** Associated tab item */
-  item: TabItem
-  /** Panel content */
-  children?: ReactNode
-  /** Whether the panel is active */
-  isActive?: boolean
-  /** Additional CSS class */
-  className?: string
-  /** Arbitrary props passthrough */
-  [key: string]: unknown
-}
-
-/**
- * Ref methods for DynTabs mini API
- * Provides programmatic control over tab focus and selection
- */
 export interface DynTabsRef {
-  /** Focus the first tab */
-  focusFirst(): void
-  /** Focus the last tab */
-  focusLast(): void
-  /** Focus tab with specific value */
-  focus(value: string): void
-  /** Get currently focused tab value */
-  getFocused(): string | null
-  /** Get currently selected tab value */
-  getSelected(): string | null
+  root: HTMLDivElement | null
+  focusTab: (value: string) => void
+  focusFirstTab: () => void
+  focusLastTab: () => void
+  focusNextTab: () => void
+  focusPreviousTab: () => void
+}
+
+export interface DynTabsProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'onChange'> {
+  value?: string
+  defaultValue?: string
+  orientation?: 'horizontal' | 'vertical'
+  activation?: 'auto' | 'manual'
+  children?: ReactNode
+  className?: string
+  onChange?: (value: string) => void
+  items?: DynTabItem[]
+  'data-testid'?: string
+}
+
+export interface DynTabProps
+  extends Omit<
+    ButtonHTMLAttributes<HTMLButtonElement>,
+    | 'children'
+    | 'onSelect'
+    | 'onFocus'
+    | 'onKeyDown'
+    | 'disabled'
+    | 'type'
+  > {
+  item?: DynTabItem
+  children?: ReactNode
+  isActive?: boolean
+  onSelect?: (value: string) => void
+  onFocusTab?: (value: string) => void
+  activation?: 'auto' | 'manual'
+  disabled?: boolean
+  className?: string
+  tabId?: string
+  panelId?: string
+  onClick?: ButtonHTMLAttributes<HTMLButtonElement>['onClick']
+  onKeyDown?: ButtonHTMLAttributes<HTMLButtonElement>['onKeyDown']
+  onFocus?: ButtonHTMLAttributes<HTMLButtonElement>['onFocus']
+}
+
+export interface DynTabPanelProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
+  item?: DynTabItem
+  children?: ReactNode
+  isActive?: boolean
+  className?: string
+  panelId?: string
+  tabId?: string
 }

--- a/packages/core/src/ui/dyn-listview.tsx
+++ b/packages/core/src/ui/dyn-listview.tsx
@@ -1,4 +1,4 @@
-import { useState, forwardRef } from 'react';
+import { useState, forwardRef, useCallback, type MutableRefObject } from 'react';
 import type { DynListViewProps } from '../types/components/dyn-listview.types';
 import { useArrowNavigation } from '../hooks/use-arrow-navigation';
 import { classNames } from '../utils';
@@ -14,11 +14,24 @@ export const DynListView = forwardRef<HTMLDivElement, DynListViewProps>(
     ...props
   }, ref) => {
     const [selectedItems, setSelectedItems] = useState<string[]>([]);
-    
+
     const { containerRef } = useArrowNavigation({
       orientation: 'vertical',
       selector: '.dyn-list-item:not(.dyn-list-item--disabled)'
     });
+
+    const assignRefs = useCallback(
+      (node: HTMLDivElement | null) => {
+        (containerRef as MutableRefObject<HTMLDivElement | null>).current = node;
+        if (!ref) return;
+        if (typeof ref === 'function') {
+          (ref as (instance: HTMLDivElement | null) => void)(node);
+        } else {
+          (ref as MutableRefObject<HTMLDivElement | null>).current = node;
+        }
+      },
+      [containerRef, ref]
+    );
 
     const handleItemSelect = (itemId: string) => {
       if (multiSelect) {
@@ -35,7 +48,7 @@ export const DynListView = forwardRef<HTMLDivElement, DynListViewProps>(
     return (
       <div
         {...props}
-        ref={ref || (containerRef as React.RefObject<HTMLDivElement>)}
+        ref={assignRefs}
         role="listbox"
         aria-multiselectable={multiSelect}
         className={classNames('dyn-list-view', className)}

--- a/packages/core/src/ui/dyn-menu.tsx
+++ b/packages/core/src/ui/dyn-menu.tsx
@@ -40,19 +40,21 @@ export const DynMenu = forwardRef<HTMLDivElement, DynMenuProps>(
 DynMenu.displayName = 'DynMenu';
 
 export const DynMenuItem = forwardRef<HTMLButtonElement, DynMenuItemProps>(
-  ({ 
+  ({
     children,
     disabled = false,
     action,
     onAction,
     className,
     'data-testid': testId,
-    ...props 
+    onClick: userOnClick,
+    ...props
   }, ref) => {
-    const handleClick = () => {
+    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
       if (!disabled && action) {
         onAction?.(action);
       }
+      userOnClick?.(event);
     };
 
     return (

--- a/packages/core/src/ui/dyn-tabs.tsx
+++ b/packages/core/src/ui/dyn-tabs.tsx
@@ -1,110 +1,236 @@
-import React, { forwardRef, useState, useImperativeHandle } from 'react'
-import type { DynTabsProps, DynTabProps, DynTabPanelProps, DynTabsRef, TabItem } from '../types/components/dyn-tabs.types'
+import React, {
+  forwardRef,
+  useCallback,
+  useId,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
+import type {
+  DynTabsProps,
+  DynTabProps,
+  DynTabPanelProps,
+  DynTabsRef,
+  TabItem
+} from '../types/components/dyn-tabs.types'
 import { useArrowNavigation } from '../hooks/use-arrow-navigation'
 import { classNames } from '../utils'
 
-/**
- * DynTabs - WAI-ARIA compliant Tabs with activation modes and mini API
- * - Activation: 'auto' (activate on focus) | 'manual' (activate on Enter/Space)
- * - Orientation: 'horizontal' | 'vertical'
- * - Keyboard: Arrow keys, Home/End, typeahead (provided by useArrowNavigation)
- * - Mini API: focusFirst, focusLast, focus(value), getFocused, getSelected
- */
+const getItemValue = (item?: TabItem): string => item?.value ?? ''
+
+const sanitizeValueForId = (value: string): string => value.replace(/\s+/g, '-')
+
 export const DynTabs = forwardRef<DynTabsRef, DynTabsProps>(
   (
     {
       value,
       defaultValue,
-      onChange,
       orientation = 'horizontal',
       activation = 'auto',
       children,
       className,
-      'aria-label': ariaLabel,
+      onChange,
       'data-testid': testId,
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledBy,
       ...props
     },
     ref
   ) => {
-    const [internal, setInternal] = useState<string>(defaultValue ?? '')
-    const selected = value ?? internal
-
-    const setSelected = (next: string) => {
-      if (value === undefined) setInternal(next)
-      onChange?.(next)
-    }
-
-    const { getFocusedIndex, focusFirst, focusLast, focusIndex, setContainerRef } = useArrowNavigation({
+    const rootRef = useRef<HTMLDivElement>(null)
+    const {
+      focusFirst,
+      focusLast,
+      focusIndex,
+      getFocusableElements,
+      setContainerRef
+    } = useArrowNavigation({
       orientation,
       selector: '[role="tab"]:not([aria-disabled="true"])',
-      typeahead: true,
       loop: true
     })
+    const baseId = useId()
 
-    // Expose mini API
-    useImperativeHandle(ref, () => ({
-      focusFirst: () => focusFirst(),
-      focusLast: () => focusLast(),
-      focus: (v: string) => {
-        const items = getTabItems()
-        const idx = items.findIndex(i => i.value === v)
-        if (idx >= 0) focusIndex(idx)
-      },
-      getFocused: () => {
-        const idx = getFocusedIndex()
-        const items = getTabItems()
-        return idx >= 0 ? items[idx]?.value ?? null : null
-      },
-      getSelected: () => selected ?? null
-    }))
+    const firstAvailableValue = useMemo(() => {
+      let firstValue = ''
 
-    const getTabItems = (): TabItem[] => {
-      const items: TabItem[] = []
-      React.Children.forEach(children, (child) => {
-        if (React.isValidElement<DynTabProps>(child) && child.type === DynTab) {
-          const { item } = child.props as any
-          if (item) items.push(item)
+      React.Children.forEach(children, child => {
+        if (
+          firstValue === '' &&
+          React.isValidElement<React.ComponentProps<typeof DynTab>>(child) &&
+          child.type === DynTab &&
+          child.props.item &&
+          !child.props.item.disabled
+        ) {
+          firstValue = getItemValue(child.props.item)
         }
       })
-      return items
-    }
 
-    const handleTabActivate = (tabValue: string) => setSelected(tabValue)
+      return firstValue
+    }, [children])
+
+    const [activeTab, setActiveTab] = useState<string>(
+      () => value ?? defaultValue ?? firstAvailableValue
+    )
+
+    const handleTabChange = useCallback(
+      (tabValue: string) => {
+        if (value === undefined) {
+          setActiveTab(tabValue)
+        }
+        onChange?.(tabValue)
+      },
+      [onChange, value]
+    )
+
+    const handleTabFocus = useCallback(
+      (tabValue: string) => {
+        if (activation === 'auto') {
+          handleTabChange(tabValue)
+        }
+      },
+      [activation, handleTabChange]
+    )
+
+    const currentTab = value ?? activeTab
+
+    const focusableTabs = useCallback(() => {
+      return getFocusableElements()
+    }, [getFocusableElements])
+
+    const focusAtIndex = useCallback(
+      (index: number) => {
+        const tabs = focusableTabs()
+        const total = tabs.length
+        if (total === 0) return
+        const normalizedIndex = ((index % total) + total) % total
+        focusIndex(normalizedIndex)
+      },
+      [focusIndex, focusableTabs]
+    )
+
+    const focusTabByValue = useCallback(
+      (tabValue: string) => {
+        const tabs = focusableTabs()
+        const targetIndex = tabs.findIndex(tab => tab.dataset.value === tabValue)
+        if (targetIndex >= 0) {
+          focusAtIndex(targetIndex)
+        }
+      },
+      [focusAtIndex, focusableTabs]
+    )
+
+    const focusFirstTab = useCallback(() => {
+      focusFirst()
+    }, [focusFirst])
+
+    const focusLastTab = useCallback(() => {
+      focusLast()
+    }, [focusLast])
+
+    const focusNextTab = useCallback(() => {
+      const tabs = focusableTabs()
+      if (tabs.length === 0) return
+      const currentIndex = tabs.findIndex(tab => tab === document.activeElement)
+      const nextIndex = currentIndex >= 0 ? currentIndex + 1 : 0
+      focusAtIndex(nextIndex)
+    }, [focusAtIndex, focusableTabs])
+
+    const focusPreviousTab = useCallback(() => {
+      const tabs = focusableTabs()
+      if (tabs.length === 0) return
+      const currentIndex = tabs.findIndex(tab => tab === document.activeElement)
+      const previousIndex = currentIndex > 0 ? currentIndex - 1 : tabs.length - 1
+      focusAtIndex(previousIndex)
+    }, [focusAtIndex, focusableTabs])
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        root: rootRef.current,
+        focusTab: focusTabByValue,
+        focusFirstTab,
+        focusLastTab,
+        focusNextTab,
+        focusPreviousTab
+      }),
+      [focusFirstTab, focusLastTab, focusNextTab, focusPreviousTab, focusTabByValue]
+    )
+
+    const getItemIdentifiers = useCallback(
+      (item: TabItem) => {
+        const valueSanitized = sanitizeValueForId(item.value)
+        const tabId = item.tabId ?? `${baseId}-tab-${valueSanitized}`
+        const panelId = item.panelId ?? `${baseId}-panel-${valueSanitized}`
+
+        return { tabId, panelId }
+      },
+      [baseId]
+    )
+
+    const handleTablistRef = useCallback(
+      (node: HTMLDivElement | null) => {
+        setContainerRef(node)
+      },
+      [setContainerRef]
+    )
 
     return (
       <div
         {...props}
+        ref={rootRef}
         className={classNames('dyn-tabs', `dyn-tabs--${orientation}`, className)}
         data-testid={testId}
-        aria-label={ariaLabel}
       >
         <div
-          ref={(node) => {
-            setContainerRef(node)
-          }}
+          ref={handleTablistRef}
           role="tablist"
-          aria-orientation={orientation}
           className="dyn-tabs__list"
+          aria-orientation={orientation}
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledBy}
         >
-          {React.Children.map(children, (child) => {
-            if (React.isValidElement<DynTabProps>(child) && child.type === DynTab) {
-              const item = (child.props as any).item as TabItem
-              const isActive = item?.value === selected
+          {React.Children.map(children, child => {
+            if (
+              React.isValidElement<React.ComponentProps<typeof DynTab>>(child) &&
+              child.type === DynTab
+            ) {
+              const item = child.props.item
+              if (!item) return null
+              const { tabId, panelId } = getItemIdentifiers(item)
+              const disabledProps =
+                item.disabled !== undefined ? { disabled: item.disabled } : {}
+
               return React.cloneElement(child, {
-                isActive,
-                onSelect: handleTabActivate,
-                activation
-              } as Partial<DynTabProps>)
+                ...child.props,
+                ...disabledProps,
+                tabId,
+                panelId,
+                isActive: item.value === currentTab,
+                activation,
+                onSelect: handleTabChange,
+                onFocusTab: handleTabFocus
+              })
             }
             return null
           })}
         </div>
         <div className="dyn-tabs__content">
-          {React.Children.map(children, (child) => {
-            if (React.isValidElement<DynTabPanelProps>(child) && child.type === DynTabPanel) {
-              const item = (child.props as any).item as TabItem
-              const isActive = item?.value === selected
-              return React.cloneElement(child, { isActive } as Partial<DynTabPanelProps>)
+          {React.Children.map(children, child => {
+            if (
+              React.isValidElement<React.ComponentProps<typeof DynTabPanel>>(child) &&
+              child.type === DynTabPanel
+            ) {
+              const item = child.props.item
+              if (!item) return null
+              const { tabId, panelId } = getItemIdentifiers(item)
+              return React.cloneElement(child, {
+                ...child.props,
+                tabId,
+                panelId,
+                isActive: item.value === currentTab
+              })
             }
             return null
           })}
@@ -117,52 +243,117 @@ export const DynTabs = forwardRef<DynTabsRef, DynTabsProps>(
 DynTabs.displayName = 'DynTabs'
 
 export const DynTab = forwardRef<HTMLButtonElement, DynTabProps>(
-  ({ item, isActive, onSelect, activation = 'auto', disabled, className, ...props }, ref) => (
-    <button
-      {...props}
-      ref={ref}
-      role="tab"
-      type="button"
-      aria-selected={isActive}
-      aria-disabled={disabled}
-      tabIndex={isActive ? 0 : -1}
-      className={classNames(
-        'dyn-tab',
-        isActive && 'dyn-tab--active',
-        disabled && 'dyn-tab--disabled',
-        className
-      )}
-      onClick={() => !disabled && onSelect?.(item.value)}
-      onKeyDown={(e) => {
-        if (activation === 'manual' && (e.key === 'Enter' || e.key === ' ')) {
-          e.preventDefault()
+  (
+    {
+      item,
+      children,
+      isActive,
+      onSelect,
+      onFocusTab,
+      activation: _activation,
+      disabled = item?.disabled,
+      className,
+      tabId,
+      panelId,
+      onClick: userOnClick,
+      onKeyDown: userOnKeyDown,
+      onFocus: userOnFocus,
+      ...props
+    },
+    ref
+  ) => {
+    void _activation
+    const content = children ?? item?.label
+
+    const handleClick = useCallback(
+      (event: React.MouseEvent<HTMLButtonElement>) => {
+        if (disabled || !item) return
+        onSelect?.(item.value)
+        userOnClick?.(event)
+      },
+      [disabled, item, onSelect, userOnClick]
+    )
+
+    const handleKeyDown = useCallback(
+      (event: React.KeyboardEvent<HTMLButtonElement>) => {
+        if (disabled || !item) return
+
+        if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+          event.preventDefault()
           onSelect?.(item.value)
-        } else if (activation === 'auto' && (e.key === 'Enter' || e.key === ' ')) {
-          // Already active via focus; prevent scroll
-          e.preventDefault()
         }
-      }}
-    >
-      {item?.label ?? props.children}
-    </button>
-  )
+        userOnKeyDown?.(event)
+      },
+      [disabled, item, onSelect, userOnKeyDown]
+    )
+
+    const handleFocus = useCallback(
+      (event: React.FocusEvent<HTMLButtonElement>) => {
+        if (!disabled && item) {
+          onFocusTab?.(item.value)
+        }
+        userOnFocus?.(event)
+      },
+      [disabled, item, onFocusTab, userOnFocus]
+    )
+
+    if (!item) {
+      return null
+    }
+
+    return (
+      <button
+        {...props}
+        type="button"
+        ref={ref}
+        role="tab"
+        id={tabId}
+        data-value={item.value}
+        aria-selected={!!isActive}
+        aria-controls={panelId}
+        aria-disabled={disabled}
+        tabIndex={isActive ? 0 : -1}
+        className={classNames(
+          'dyn-tab',
+          isActive && 'dyn-tab--active',
+          disabled && 'dyn-tab--disabled',
+          item?.className,
+          className
+        )}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        onFocus={handleFocus}
+      >
+        {content}
+      </button>
+    )
+  }
 )
 
 DynTab.displayName = 'DynTab'
 
 export const DynTabPanel = forwardRef<HTMLDivElement, DynTabPanelProps>(
-  ({ item, isActive, className, ...props }, ref) => (
-    <div
-      {...props}
-      ref={ref}
-      role="tabpanel"
-      hidden={!isActive}
-      className={classNames('dyn-tab-panel', className)}
-      aria-labelledby={item?.value}
-    >
-      {props.children}
-    </div>
-  )
+  ({ item, children, isActive, className, panelId, tabId, ...props }, ref) => {
+    if (!item) {
+      return null
+    }
+
+    const content = children ?? item.panel
+
+    return (
+      <div
+        {...props}
+        ref={ref}
+        id={panelId}
+        role="tabpanel"
+        aria-labelledby={tabId}
+        hidden={!isActive}
+        className={classNames('dyn-tab-panel', className, item.className)}
+      >
+        {content}
+      </div>
+    )
+  }
 )
 
 DynTabPanel.displayName = 'DynTabPanel'

--- a/src/hooks/use-arrow-navigation.ts
+++ b/src/hooks/use-arrow-navigation.ts
@@ -1,11 +1,20 @@
-import { useRef, useCallback, useEffect } from 'react';
+import { useRef, useCallback, useEffect, type MutableRefObject } from 'react';
 
 export interface ArrowNavigationOptions {
   orientation?: 'horizontal' | 'vertical' | 'both';
   selector?: string;
 }
 
-export function useArrowNavigation(options: ArrowNavigationOptions = {}) {
+export interface ArrowNavigationResult {
+  containerRef: MutableRefObject<HTMLDivElement | null>;
+  focusFirst: () => void;
+  focusLast: () => void;
+  focusAtIndex: (index: number) => void;
+}
+
+export function useArrowNavigation(
+  options: ArrowNavigationOptions = {}
+): ArrowNavigationResult {
   const {
     orientation = 'vertical',
     selector = '[tabindex="0"], button:not(:disabled), input:not(:disabled)'

--- a/src/types/components/dyn-tabs.types.ts
+++ b/src/types/components/dyn-tabs.types.ts
@@ -1,4 +1,8 @@
-import type { ReactNode } from 'react';
+import type {
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  ReactNode
+} from 'react';
 
 export interface TabItem {
   value: string;
@@ -24,7 +28,8 @@ export interface DynTabsRef {
   focusPreviousTab: () => void;
 }
 
-export interface DynTabsProps {
+export interface DynTabsProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'onChange'> {
   value?: string;
   defaultValue?: string;
   orientation?: 'horizontal' | 'vertical';
@@ -33,12 +38,19 @@ export interface DynTabsProps {
   className?: string;
   onChange?: (value: string) => void;
   items?: DynTabItem[];
-  'aria-label'?: string;
-  'aria-labelledby'?: string;
   'data-testid'?: string;
 }
 
-export interface DynTabProps {
+export interface DynTabProps
+  extends Omit<
+    ButtonHTMLAttributes<HTMLButtonElement>,
+    | 'children'
+    | 'onSelect'
+    | 'onFocus'
+    | 'onKeyDown'
+    | 'disabled'
+    | 'type'
+  > {
   item?: DynTabItem;
   children?: ReactNode;
   isActive?: boolean;
@@ -49,9 +61,13 @@ export interface DynTabProps {
   className?: string;
   tabId?: string;
   panelId?: string;
+  onClick?: ButtonHTMLAttributes<HTMLButtonElement>['onClick'];
+  onKeyDown?: ButtonHTMLAttributes<HTMLButtonElement>['onKeyDown'];
+  onFocus?: ButtonHTMLAttributes<HTMLButtonElement>['onFocus'];
 }
 
-export interface DynTabPanelProps {
+export interface DynTabPanelProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
   item?: DynTabItem;
   children?: ReactNode;
   isActive?: boolean;

--- a/src/ui/dyn-tabs.tsx
+++ b/src/ui/dyn-tabs.tsx
@@ -226,20 +226,29 @@ export const DynTab = forwardRef<HTMLButtonElement, DynTabProps>(
       isActive,
       onSelect,
       onFocusTab,
+      activation: _activation,
       disabled = item?.disabled,
       className,
       tabId,
       panelId,
+      onClick: userOnClick,
+      onKeyDown: userOnKeyDown,
+      onFocus: userOnFocus,
       ...props
     },
     ref
   ) => {
+    void _activation;
     const content = children ?? item?.label;
 
-    const handleClick = useCallback(() => {
-      if (disabled || !item) return;
-      onSelect?.(item.value);
-    }, [disabled, item, onSelect]);
+    const handleClick = useCallback(
+      (event: React.MouseEvent<HTMLButtonElement>) => {
+        if (disabled || !item) return;
+        onSelect?.(item.value);
+        userOnClick?.(event);
+      },
+      [disabled, item, onSelect, userOnClick]
+    );
 
     const handleKeyDown = useCallback(
       (event: React.KeyboardEvent<HTMLButtonElement>) => {
@@ -249,14 +258,20 @@ export const DynTab = forwardRef<HTMLButtonElement, DynTabProps>(
           event.preventDefault();
           onSelect?.(item.value);
         }
+        userOnKeyDown?.(event);
       },
-      [disabled, item, onSelect]
+      [disabled, item, onSelect, userOnKeyDown]
     );
 
-    const handleFocus = useCallback(() => {
-      if (disabled || !item) return;
-      onFocusTab?.(item.value);
-    }, [disabled, item, onFocusTab]);
+    const handleFocus = useCallback(
+      (event: React.FocusEvent<HTMLButtonElement>) => {
+        if (!disabled && item) {
+          onFocusTab?.(item.value);
+        }
+        userOnFocus?.(event);
+      },
+      [disabled, item, onFocusTab, userOnFocus]
+    );
 
     if (!item) {
       return null;


### PR DESCRIPTION
## Summary
- rewrite the DynTabs implementation to derive stable ids, expose an imperative API, and integrate the shared arrow-navigation hook while cloning tab children with consistent props
- expand DynTab, DynTabs, and related type definitions to extend native HTML attributes and surface optional event overrides in both the root and package sources
- adjust DynMenu and DynListView typings/components to eliminate `unknown` passthrough props and support user click handlers, and document the arrow navigation hook return shape

## Testing
- `pnpm --filter @dynui/core build` *(fails: existing DynTextarea change handler typing is incompatible)*

------
https://chatgpt.com/codex/tasks/task_e_68fd38216cc48324ba2685ad0a2302f6