### PR TITLE
Fix turbo config root key for turbo@2

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "build/**", "storybook-static/**"],


### PR DESCRIPTION
## Summary
- restore the top-level turbo configuration key to `tasks` so it matches turbo@2's schema

## Testing
- node ./tools/run-turbo-task.js lint --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68fd516847d0832491f97281b92bcb61