### PR TITLE
Fix exported tsconfig base dependency

### DIFF
--- a/tools/build-config/package.json
+++ b/tools/build-config/package.json
@@ -12,6 +12,7 @@
   },
   "files": [
     "tsconfig.base.json",
+    "tsconfig.shared.json",
     "tsup.library.config.js",
     "tsup.library.config.d.ts",
     "README.md"

--- a/tools/build-config/tsconfig.base.json
+++ b/tools/build-config/tsconfig.base.json
@@ -1,26 +1,4 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": true,
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "removeComments": true,
-    "jsx": "react-jsx"
-  },
-  "exclude": ["dist", "build", "node_modules", "storybook-static"]
+  "extends": "./tsconfig.shared.json"
 }

--- a/tools/build-config/tsconfig.shared.json
+++ b/tools/build-config/tsconfig.shared.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "removeComments": true,
+    "jsx": "react-jsx"
+  },
+  "exclude": ["dist", "build", "node_modules", "storybook-static"]
+}


### PR DESCRIPTION
## Summary
- add an internal shared tsconfig fragment for build-config consumers
- have the published tsconfig base extend the local shared file instead of the repository root
- publish the shared fragment with the build-config package so downstream extends continue to resolve

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd5574bec4832498a1708a2d820fe7