### PR TITLE
Restore root tsconfig exclude paths

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,9 @@
 {
-  "extends": "./tools/build-config/tsconfig.base.json"
+  "extends": "./tools/build-config/tsconfig.base.json",
+  "exclude": [
+    "./dist",
+    "./build",
+    "./node_modules",
+    "./storybook-static"
+  ]
 }


### PR DESCRIPTION
## Summary
- restore the root TypeScript configuration's local exclude list so temporary build outputs under the repo root stay out of type checking

## Testing
- pnpm exec tsc -p tsconfig.json --showConfig

------
https://chatgpt.com/codex/tasks/task_e_68fd584d27688324835ac90655491c7a