### PR TITLE
Align TypeScript paths and Turbo configuration for phase 2

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -6,8 +6,8 @@
     "baseUrl": ".",
     "composite": true,
     "paths": {
-      "@dynui/design-tokens": ["../design-tokens/src/index.ts"],
-      "@dynui/icons": ["../icons/src/index.ts"]
+      "@dynui/design-tokens": ["../design-tokens/src"],
+      "@dynui/icons": ["../icons/src"]
     }
   },
   "references": [

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- point the core package path aliases at the package source directories to match the phase 2 layout
- add the workspace `extends` entry to turbo.json so the v2 schema is honored without breaking turbo 2.x

## Testing
- `pnpm turbo run typecheck` *(fails: @dynui/core build DTS project excludes component/theme index files)*

------
https://chatgpt.com/codex/tasks/task_e_68fd493db8188324bbd711e1df9e90ce