### PR TITLE
Fix core type definitions to restore typecheck

### DIFF
--- a/packages/core/src/hooks/use-controlled.ts
+++ b/packages/core/src/hooks/use-controlled.ts
@@ -5,11 +5,11 @@ import { useState, useCallback } from 'react'
  */
 export interface UseControlledOptions<T> {
   /** Controlled value */
-  value?: T
+  value?: T | undefined
   /** Default value for uncontrolled mode */
-  defaultValue?: T
+  defaultValue?: T | undefined
   /** Change handler */
-  onChange?: (value: T) => void
+  onChange?: ((value: T) => void) | undefined
 }
 
 /**

--- a/packages/core/src/hooks/use-focus-trap.ts
+++ b/packages/core/src/hooks/use-focus-trap.ts
@@ -15,18 +15,18 @@ const FOCUSABLE_SELECTOR = [
   '[tabindex]:not([tabindex="-1"])'
 ].join(', ')
 
-export function useFocusTrap({
+export function useFocusTrap<T extends HTMLElement = HTMLElement>({
   enabled = true,
   initialFocus = true,
   returnFocus = true
 }: UseFocusTrapOptions = {}) {
-  const containerRef = useRef<HTMLElement>(null)
+  const containerRef = useRef<T>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
     if (!enabled || !containerRef.current) return
 
-    const container = containerRef.current
+    const container = containerRef.current as HTMLElement
     previousFocusRef.current = document.activeElement as HTMLElement
 
     const focusableElements = container.querySelectorAll(FOCUSABLE_SELECTOR) as NodeListOf<HTMLElement>

--- a/packages/core/src/icons/icon-dictionary-provider.tsx
+++ b/packages/core/src/icons/icon-dictionary-provider.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, ReactNode, useState, useCallback } from 'react'
+import { createContext, useState, useCallback } from 'react'
+import type { ReactNode } from 'react'
 import type { IconDictionary, IconRegistryContextType, IconComponent } from './icons.types'
 
 const IconDictionaryContext = createContext<IconRegistryContextType | undefined>(undefined)

--- a/packages/core/src/icons/icons.types.ts
+++ b/packages/core/src/icons/icons.types.ts
@@ -1,5 +1,3 @@
-import type { ReactNode } from 'react'
-
 /**
  * Icon component type - can be any React component that renders an icon
  */

--- a/packages/core/src/types/components/dyn-stubs.types.ts
+++ b/packages/core/src/types/components/dyn-stubs.types.ts
@@ -1,10 +1,14 @@
 import type {
   ButtonHTMLAttributes,
+  ComponentPropsWithoutRef,
+  ElementType,
   HTMLAttributes,
+  InputHTMLAttributes,
+  TableHTMLAttributes,
   ReactNode,
   ChangeEvent,
   FocusEvent,
-  MouseEvent
+  MouseEventHandler
 } from 'react'
 
 export interface DynCheckboxProps {
@@ -25,7 +29,8 @@ export interface DynCheckboxProps {
   'data-testid'?: string
 }
 
-export interface DynRadioProps {
+export interface DynRadioProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'size' | 'children'> {
   value: string
   name?: string
   checked?: boolean
@@ -35,14 +40,11 @@ export interface DynRadioProps {
   className?: string
   children?: ReactNode
   onChange?: (value: string, event: ChangeEvent<HTMLInputElement>) => void
-  'aria-label'?: string
-  'aria-labelledby'?: string
-  'aria-describedby'?: string
   'data-testid'?: string
-  [key: string]: unknown
 }
 
-export interface DynRadioGroupProps {
+export interface DynRadioGroupProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'children'> {
   value?: string
   defaultValue?: string
   name?: string
@@ -51,12 +53,7 @@ export interface DynRadioGroupProps {
   onChange?: (value: string, event: ChangeEvent<HTMLInputElement>) => void
   multiSelect?: boolean
   children?: ReactNode
-  className?: string
-  'aria-label'?: string
-  'aria-labelledby'?: string
-  'aria-describedby'?: string
   'data-testid'?: string
-  [key: string]: unknown
 }
 
 export type DynStepperProps = Record<string, unknown>
@@ -96,7 +93,7 @@ export interface DynBreadcrumbItemProps {
   href?: string
   current?: boolean
   disabled?: boolean
-  onClick?: (event: MouseEvent<HTMLElement>) => void
+  onClick?: MouseEventHandler<HTMLElement>
   'aria-current'?: 'page' | 'step' | 'location' | 'date' | 'time' | 'true' | 'false'
   'data-testid'?: string
   [key: string]: unknown
@@ -150,14 +147,12 @@ export interface DynTableColumn {
   sortable?: boolean
 }
 
-export interface DynTableProps {
+export interface DynTableProps extends Omit<TableHTMLAttributes<HTMLTableElement>, 'onSort'> {
   columns: DynTableColumn[]
   data: Array<Record<string, ReactNode>>
   sortable?: boolean
   onSort?: (columnKey: string, direction: 'asc' | 'desc') => void
-  className?: string
   'data-testid'?: string
-  [key: string]: unknown
 }
 
 export interface DynTableSort {
@@ -173,19 +168,17 @@ export interface TreeNode {
   children?: TreeNode[]
 }
 
-export interface DynTreeViewProps {
+export interface DynTreeViewProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'onSelect'> {
   data?: TreeNode[]
   selectedNode?: string
   expandedNodes?: string[]
   onNodeSelect?: (id: string) => void
   onNodeExpand?: (id: string) => void
   multiSelect?: boolean
-  className?: string
   'data-testid'?: string
-  [key: string]: unknown
 }
 
-export interface DynTreeNodeProps {
+export interface DynTreeNodeProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'onToggle'> {
   node: TreeNode
   level?: number
   expanded?: boolean
@@ -193,21 +186,15 @@ export interface DynTreeNodeProps {
   hasChildren?: boolean
   onToggle?: () => void
   onSelect?: () => void
-  className?: string
-  [key: string]: unknown
 }
 
-export interface DynBoxProps {
-  as?: keyof JSX.IntrinsicElements
+export type DynBoxProps<T extends ElementType = 'div'> = {
+  as?: T
   p?: number | string
   m?: number | string
   gap?: number | string
-  children?: ReactNode
-  className?: string
-  style?: Record<string, unknown>
   'data-testid'?: string
-  [key: string]: unknown
-}
+} & Omit<ComponentPropsWithoutRef<T>, 'as' | 'p' | 'm' | 'gap'>
 
 export interface DynContainerProps {
   as?: keyof JSX.IntrinsicElements
@@ -220,25 +207,17 @@ export interface DynContainerProps {
   [key: string]: unknown
 }
 
-export interface DynGridProps {
+export interface DynGridProps extends HTMLAttributes<HTMLDivElement> {
   columns?: number | string
   rows?: number | string
   gap?: number | string
-  children?: ReactNode
-  className?: string
-  style?: Record<string, unknown>
   'data-testid'?: string
-  [key: string]: unknown
 }
 
-export interface DynGridItemProps {
+export interface DynGridItemProps extends HTMLAttributes<HTMLDivElement> {
   colSpan?: number | string
   rowSpan?: number | string
-  children?: ReactNode
-  className?: string
-  style?: Record<string, unknown>
   'data-testid'?: string
-  [key: string]: unknown
 }
 
 export interface DynFieldContainerProps {

--- a/packages/core/src/ui/dyn-box.tsx
+++ b/packages/core/src/ui/dyn-box.tsx
@@ -1,23 +1,35 @@
+import type { ElementType } from 'react'
 import type { DynBoxProps } from '../types/components/dyn-box.types'
 import { classNames, getSpacingStyles } from '../utils'
 
-export function DynBox({
-  as: As = 'div',
+export function DynBox<T extends ElementType = 'div'>({
+  as,
   children,
   p,
   m,
   gap,
   className,
+  style,
   'data-testid': dataTestId,
   ...props
-}: DynBoxProps) {
+}: DynBoxProps<T>) {
+  const As = (as ?? 'div') as ElementType
   const cls = classNames('dyn-box', className)
-  const styles = getSpacingStyles({ p, m, gap })
+  const spacing = {
+    ...(p !== undefined ? { p } : {}),
+    ...(m !== undefined ? { m } : {}),
+    ...(gap !== undefined ? { gap } : {})
+  }
+  const spacingStyles = getSpacingStyles(spacing)
+  const mergedStyle = {
+    ...spacingStyles,
+    ...(style as Record<string, unknown> | undefined)
+  }
 
   return (
     <As
       className={cls}
-      style={styles}
+      style={mergedStyle as typeof spacingStyles}
       data-testid={dataTestId}
       {...props}
     >

--- a/packages/core/src/ui/dyn-breadcrumb.tsx
+++ b/packages/core/src/ui/dyn-breadcrumb.tsx
@@ -1,3 +1,4 @@
+import type { ElementType } from 'react'
 import type { DynBreadcrumbProps, DynBreadcrumbItemProps } from '../types/components/dyn-breadcrumb.types'
 import { classNames } from '../utils'
 
@@ -54,17 +55,24 @@ export function DynBreadcrumbItem({
     disabled && 'dyn-breadcrumb-item--disabled'
   )
 
-  const Component = href ? 'a' : As
+  const Component = (href ? 'a' : As) as ElementType
+
+  const componentProps: Record<string, unknown> = {
+    className: cls,
+    'aria-current': current ? (ariaCurrent || 'page') : undefined,
+    'data-testid': dataTestId,
+    children
+  }
+
+  if (href) {
+    componentProps.href = href
+  }
+
+  if (onClick) {
+    componentProps.onClick = onClick
+  }
 
   return (
-    <Component
-      className={cls}
-      href={href}
-      onClick={onClick}
-      aria-current={current ? (ariaCurrent || 'page') : undefined}
-      data-testid={dataTestId}
-    >
-      {children}
-    </Component>
+    <Component {...componentProps} />
   )
 }

--- a/packages/core/src/ui/dyn-divider.tsx
+++ b/packages/core/src/ui/dyn-divider.tsx
@@ -14,7 +14,7 @@ export function DynDivider({
     `dyn-divider--${orientation}`,
     `dyn-divider--${variant}`,
     `dyn-divider--${size}`,
-    label && 'dyn-divider--with-label'
+    label ? 'dyn-divider--with-label' : undefined
   )
 
   return (

--- a/packages/core/src/ui/dyn-grid.tsx
+++ b/packages/core/src/ui/dyn-grid.tsx
@@ -1,4 +1,5 @@
 import { forwardRef } from 'react';
+import type { CSSProperties } from 'react';
 import type { DynGridProps, DynGridItemProps } from '../types/components/dyn-grid.types';
 import { getSpacingStyles, classNames } from '../utils';
 
@@ -14,18 +15,23 @@ export const DynGrid = forwardRef<HTMLDivElement, DynGridProps>(
     ...props 
   }, ref) => {
     // Filter out undefined values for exactOptionalPropertyTypes
-    const spacingArgs: { gap?: number | string } = {};
-    if (gap !== undefined) spacingArgs.gap = gap;
-    
-    const spacingStyles = getSpacingStyles(spacingArgs);
+    const spacingStyles = getSpacingStyles(gap !== undefined ? { gap } : {});
 
-    const combinedStyle = {
+    const combinedStyle: CSSProperties = {
       ...spacingStyles,
-      gridTemplateColumns: columns ? 
-        (typeof columns === 'number' ? `repeat(${columns}, 1fr)` : columns) : undefined,
-      gridTemplateRows: rows && Number(rows) > 0 ? 
-        (typeof rows === 'number' ? `repeat(${rows}, 1fr)` : rows) : undefined,
-      ...style
+      ...(columns !== undefined
+        ? {
+            gridTemplateColumns:
+              typeof columns === 'number' ? `repeat(${columns}, 1fr)` : columns
+          }
+        : {}),
+      ...(rows !== undefined
+        ? {
+            gridTemplateRows:
+              typeof rows === 'number' ? `repeat(${rows}, 1fr)` : rows
+          }
+        : {}),
+      ...(style ?? {})
     };
 
     return (
@@ -34,8 +40,12 @@ export const DynGrid = forwardRef<HTMLDivElement, DynGridProps>(
         ref={ref}
         className={classNames(
           'dyn-grid',
-          columns && Number(columns) > 0 && `dyn-grid--columns-${columns}`,
-          rows && Number(rows) > 0 && `dyn-grid--rows-${rows}`,
+          columns !== undefined && columns !== null && Number(columns) > 0
+            ? `dyn-grid--columns-${columns}`
+            : undefined,
+          rows !== undefined && rows !== null && Number(rows) > 0
+            ? `dyn-grid--rows-${rows}`
+            : undefined,
           className
         )}
         style={combinedStyle}
@@ -64,13 +74,22 @@ export const DynGridItem = forwardRef<HTMLDivElement, DynGridItemProps>(
         ref={ref}
         className={classNames(
           'dyn-grid-item',
-          colSpan && Number(colSpan) > 0 && `dyn-grid-item--col-span-${colSpan}`,
-          rowSpan && Number(rowSpan) > 0 && `dyn-grid-item--row-span-${rowSpan}`,
+          colSpan !== undefined && colSpan !== null && Number(colSpan) > 0
+            ? `dyn-grid-item--col-span-${colSpan}`
+            : undefined,
+          rowSpan !== undefined && rowSpan !== null && Number(rowSpan) > 0
+            ? `dyn-grid-item--row-span-${rowSpan}`
+            : undefined,
           className
         )}
         style={{
-          gridColumn: colSpan && Number(colSpan) > 0 ? `span ${colSpan}` : undefined,
-          gridRow: rowSpan && Number(rowSpan) > 0 ? `span ${rowSpan}` : undefined
+          ...(colSpan !== undefined && colSpan !== null && Number(colSpan) > 0
+            ? { gridColumn: `span ${colSpan}` }
+            : {}),
+          ...(rowSpan !== undefined && rowSpan !== null && Number(rowSpan) > 0
+            ? { gridRow: `span ${rowSpan}` }
+            : {}),
+          ...(props.style as CSSProperties | undefined)
         }}
         data-testid={testId}
       >

--- a/packages/core/src/ui/dyn-modal.tsx
+++ b/packages/core/src/ui/dyn-modal.tsx
@@ -15,7 +15,7 @@ export function DynModal({
   'aria-describedby': ariaDescribedby,
   'data-testid': dataTestId
 }: DynModalProps) {
-  const focusTrapRef = useFocusTrap({ 
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({
     enabled: isOpen,
     returnFocus: true 
   })

--- a/packages/core/src/ui/dyn-table.tsx
+++ b/packages/core/src/ui/dyn-table.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, useState } from 'react';
+import type { RefObject } from 'react';
 import type { DynTableProps, DynTableSort } from '../types/components/dyn-table.types';
 import { useArrowNavigation } from '../hooks/use-arrow-navigation';
 import { classNames } from '../utils';
@@ -39,7 +40,7 @@ export const DynTable = forwardRef<HTMLTableElement, DynTableProps>(
     });
 
     return (
-      <div ref={containerRef as React.RefObject<HTMLDivElement>} className={classNames('dyn-table-container', className)}>
+      <div ref={containerRef as RefObject<HTMLDivElement>} className={classNames('dyn-table-container', className)}>
         <table
           {...props}
           ref={ref}
@@ -56,7 +57,7 @@ export const DynTable = forwardRef<HTMLTableElement, DynTableProps>(
                   aria-sort={getAriaSort(column.key)}
                   className={classNames(
                     'dyn-table__header',
-                    sortable && column.sortable && 'dyn-table__header--sortable'
+                    sortable && column.sortable ? 'dyn-table__header--sortable' : undefined
                   )}
                   onClick={sortable && column.sortable ? () => handleSort(column.key) : undefined}
                   tabIndex={sortable && column.sortable ? 0 : -1}

--- a/packages/core/src/ui/dyn-textarea.tsx
+++ b/packages/core/src/ui/dyn-textarea.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react'
 import type { DynTextAreaProps } from '../types/components/dyn-textarea.types'
 import { useControlled } from '../hooks/use-controlled'
+import type { UseControlledOptions } from '../hooks/use-controlled'
 import { classNames } from '../utils'
 
 /**
@@ -33,21 +34,30 @@ export const DynTextArea = forwardRef<HTMLTextAreaElement, DynTextAreaProps>(
     },
     ref
   ) => {
-    const { value: currentValue, setValue } = useControlled({ value, defaultValue, onChange })
+    const controlOptions: UseControlledOptions<string> = {
+      onChange,
+      defaultValue: defaultValue ?? ''
+    }
+
+    if (value !== undefined) {
+      controlOptions.value = value
+    }
+
+    const { value: currentValue, setValue } = useControlled<string>(controlOptions)
 
     const textareaClasses = classNames(
       'dyn-textarea',
       `dyn-textarea--${size}`,
       `dyn-textarea--${variant}`,
       `dyn-textarea--resize-${resize}`,
-      disabled && 'dyn-textarea--disabled',
-      readonly && 'dyn-textarea--readonly',
-      required && 'dyn-textarea--required'
+      disabled ? 'dyn-textarea--disabled' : undefined,
+      readonly ? 'dyn-textarea--readonly' : undefined,
+      required ? 'dyn-textarea--required' : undefined
     )
 
     const wrapperClasses = classNames(
       'dyn-textarea-wrapper',
-      dataState && `dyn-textarea-wrapper--${dataState}`
+      dataState ? `dyn-textarea-wrapper--${dataState}` : undefined
     )
 
     return (
@@ -71,6 +81,7 @@ export const DynTextArea = forwardRef<HTMLTextAreaElement, DynTextAreaProps>(
           aria-labelledby={ariaLabelledby}
           aria-describedby={ariaDescribedby}
           aria-invalid={dataState === 'error' ? 'true' : undefined}
+          aria-required={required ? 'true' : undefined}
         />
       </div>
     )

--- a/packages/core/src/utils/generate-initials.ts
+++ b/packages/core/src/utils/generate-initials.ts
@@ -7,9 +7,14 @@ export function generateInitials(name: string): string {
   if (!name?.trim()) return '??'
   
   const words = name.trim().split(/\s+/)
-  if (words.length === 1) {
-    return words[0].charAt(0).toUpperCase()
+  const [firstWord, secondWord] = words
+
+  const firstInitial = firstWord?.charAt(0)?.toUpperCase() ?? ''
+  if (!secondWord) {
+    return firstInitial || '??'
   }
-  
-  return (words[0].charAt(0) + words[1].charAt(0)).toUpperCase()
+
+  const secondInitial = secondWord.charAt(0).toUpperCase()
+  const initials = `${firstInitial}${secondInitial}`.trim()
+  return initials || '??'
 }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,6 +1,8 @@
 // DynUI Utilities - Complete Export
 // Migration from src/utils/ to packages/core/src/utils/
 
+import type { CSSProperties } from 'react'
+
 export * from './class-names'
 export * from './generate-initials'
 export * from './style-props'
@@ -10,12 +12,16 @@ export function classNames(...classes: Array<string | false | null | undefined>)
   return classes.filter(Boolean).join(' ')
 }
 
-export function getSpacingStyles(
-  { p, m, gap }: { p?: number | string; m?: number | string; gap?: number | string }
-): React.CSSProperties {
-  const styles: React.CSSProperties = {}
+type SpacingShorthand = {
+  p?: number | string | undefined
+  m?: number | string | undefined
+  gap?: number | string | undefined
+}
+
+export function getSpacingStyles({ p, m, gap }: SpacingShorthand): CSSProperties {
+  const styles: CSSProperties = {}
   if (p !== undefined) styles.padding = typeof p === 'number' ? `${p}px` : p
   if (m !== undefined) styles.margin = typeof m === 'number' ? `${m}px` : m
-  if (gap !== undefined) (styles as any).gap = typeof gap === 'number' ? `${gap}px` : gap
+  if (gap !== undefined) styles.gap = typeof gap === 'number' ? `${gap}px` : gap
   return styles
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -16,11 +16,6 @@
     { "path": "../design-tokens" },
     { "path": "../icons" }
   ],
-  "files": [
-    "src/index.ts",
-    "src/components/index.ts",
-    "src/theme/index.ts"
-  ],
   "include": [
     "src/**/*.ts", 
     "src/**/*.tsx",


### PR DESCRIPTION
## Summary
- remove the explicit `files` list from the core tsconfig so new sources are picked up by the build
- loosen shared hooks and component type stubs to accept optional values and DOM attributes required at runtime
- update the affected UI components to comply with the stricter typing and add the necessary runtime guards

## Testing
- pnpm -C packages/core typecheck
- pnpm -C packages/core build

------
https://chatgpt.com/codex/tasks/task_e_68fd6cecaab88324b8e687c29bbb7b33