### PR TITLE
Fix dyn radio group orientation and name handling

### DIFF
--- a/packages/core/src/ui/dyn-radio.tsx
+++ b/packages/core/src/ui/dyn-radio.tsx
@@ -6,6 +6,7 @@ import {
   isValidElement,
   MutableRefObject,
   useCallback,
+  useEffect,
   useRef
 } from 'react'
 import type { InputHTMLAttributes } from 'react'
@@ -94,15 +95,20 @@ export const DynRadioGroup = forwardRef<HTMLDivElement, DynRadioGroupProps>(
     'data-testid': testId,
     ...props
   }, ref) => {
-    const orientationValue = orientation ?? 'vertical';
+    const orientationValue = orientation ?? 'vertical'
     const { containerRef } = useArrowNavigation({
-      orientation: orientation ?? 'vertical',
+      orientation: orientationValue,
       selector: 'input[type="radio"]:not(:disabled)'
     })
 
     const fallbackNameRef = useRef(
       name ?? `radio-group-${Math.random().toString(36).slice(2, 11)}`
     )
+    useEffect(() => {
+      if (name) {
+        fallbackNameRef.current = name
+      }
+    }, [name])
     const groupName = name ?? fallbackNameRef.current
 
     const setGroupRef = useCallback(
@@ -125,11 +131,6 @@ export const DynRadioGroup = forwardRef<HTMLDivElement, DynRadioGroupProps>(
       }
     }
 
-    const groupName = useMemo(
-      () => name ?? `radio-group-${Math.random().toString(36).slice(2, 11)}`,
-      [name]
-    );
-
     return (
       <div
         {...props}
@@ -141,7 +142,7 @@ export const DynRadioGroup = forwardRef<HTMLDivElement, DynRadioGroupProps>(
         data-testid={testId}
         className={classNames(
           'dyn-radio-group',
-          orientation ? `dyn-radio-group--${orientation}` : undefined,
+          orientationValue ? `dyn-radio-group--${orientationValue}` : undefined,
           disabled ? 'dyn-radio-group--disabled' : undefined,
           typeof className === 'string' ? className : undefined
         )}


### PR DESCRIPTION
## Summary
- reuse the resolved orientation value when wiring arrow navigation and CSS classes in DynRadioGroup
- stabilize the generated group name and remove the duplicate declaration
- keep the fallback name in sync when an explicit name prop is provided

## Testing
- pnpm --filter @dynui/core typecheck *(fails: existing errors in dyn-box and dyn-breadcrumb)*

------
https://chatgpt.com/codex/tasks/task_e_68fd771eef788324b1dccdf72a3372b8