### PR TITLE
Fix DynBox props typing

### DIFF
--- a/packages/core/src/types/components/dyn-stubs.types.ts
+++ b/packages/core/src/types/components/dyn-stubs.types.ts
@@ -1,14 +1,17 @@
 import type {
   ButtonHTMLAttributes,
+  ChangeEvent,
+  ComponentPropsWithoutRef,
   CSSProperties,
+  ElementType,
+  FocusEvent,
   HTMLAttributes,
   InputHTMLAttributes,
+  MouseEventHandler,
   ReactNode,
-  TableHTMLAttributes,
-  ChangeEvent,
-  FocusEvent,
-  MouseEventHandler
+  TableHTMLAttributes
 } from 'react'
+import type { SpacingValue } from '../common.types'
 
 export interface DynCheckboxProps {
   id?: string
@@ -183,14 +186,14 @@ export interface DynTreeNodeProps extends Omit<HTMLAttributes<HTMLDivElement>, '
   'data-testid'?: string
 }
 
-export interface DynBoxProps extends HTMLAttributes<HTMLElement> {
-  as?: keyof JSX.IntrinsicElements
-  p?: number | string
-  m?: number | string
-  gap?: number | string
+export type DynBoxProps<T extends ElementType = 'div'> = {
+  as?: T
+  p?: SpacingValue
+  m?: SpacingValue
+  gap?: SpacingValue
   style?: CSSProperties
   'data-testid'?: string
-}
+} & Omit<ComponentPropsWithoutRef<T>, 'as'>
 
 export interface DynContainerProps {
   as?: keyof JSX.IntrinsicElements

--- a/packages/core/src/ui/dyn-box.tsx
+++ b/packages/core/src/ui/dyn-box.tsx
@@ -21,10 +21,15 @@ export function DynBox<T extends ElementType = 'div'>({
     ...(gap !== undefined ? { gap } : {})
   })
 
+  const combinedStyle = {
+    ...spacingStyles,
+    ...(style ?? {})
+  }
+
   return (
     <As
       className={cls}
-      style={spacingStyles}
+      style={combinedStyle}
       data-testid={dataTestId}
       {...(props as Record<string, unknown>)}
     >

--- a/packages/core/src/ui/dyn-breadcrumb.tsx
+++ b/packages/core/src/ui/dyn-breadcrumb.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent as ReactMouseEvent, MouseEventHandler } from 'react'
+import type { ElementType, MouseEvent as ReactMouseEvent, MouseEventHandler } from 'react'
 import type { DynBreadcrumbProps, DynBreadcrumbItemProps } from '../types/components/dyn-breadcrumb.types'
 import { classNames } from '../utils'
 


### PR DESCRIPTION
## Summary
- make `DynBoxProps` generic so it can adapt native props for custom elements
- merge computed spacing styles with incoming styles in `DynBox`
- fix missing `ElementType` import in the breadcrumb component

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68fd788e7b8883248fe4ce566264285c