### PR TITLE
fix: ensure lint scripts fail on ESLint errors

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -6,7 +6,7 @@
     "storybook": "storybook dev -p 6006",
     "build:storybook": "storybook build",
     "test:storybook": "test-storybook",
-    "lint": "eslint --config ../../eslint.config.js \"src/**/*.{ts,tsx}\" || echo \"No files to lint\"",
+    "lint": "node ../../tools/run-eslint-if-files.cjs --config ../../eslint.config.js \"src/**/*.{ts,tsx}\"",
     "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\""
   },
   "dependencies": {

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -17,7 +17,7 @@
     "dev": "tsup --config tsup.config.ts --watch",
     "build:css": "node ./build/generate-css-variables.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "lint": "eslint --config ../../eslint.config.js \"src/**/*.{ts,tsx}\" || echo \"No files to lint\"",
+    "lint": "node ../../tools/run-eslint-if-files.cjs --config ../../eslint.config.js \"src/**/*.{ts,tsx}\"",
     "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\""
   },
   "devDependencies": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -15,7 +15,7 @@
     "build": "tsup --config tsup.config.ts",
     "dev": "tsup --config tsup.config.ts --watch",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "lint": "eslint --config ../../eslint.config.js \"src/**/*.{ts,tsx}\" || echo \"No files to lint\"",
+    "lint": "node ../../tools/run-eslint-if-files.cjs --config ../../eslint.config.js \"src/**/*.{ts,tsx}\"",
     "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\""
   },
   "devDependencies": {

--- a/tools/run-eslint-if-files.cjs
+++ b/tools/run-eslint-if-files.cjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('node:child_process');
+
+const eslintArgs = process.argv.slice(2);
+
+if (eslintArgs.length === 0) {
+  console.error('Usage: run-eslint-if-files <eslint args...>');
+  process.exit(1);
+}
+
+const result = spawnSync('pnpm', ['exec', 'eslint', ...eslintArgs], {
+  stdio: 'pipe',
+  encoding: 'utf8',
+});
+
+if (result.stdout) {
+  process.stdout.write(result.stdout);
+}
+
+if (result.stderr) {
+  process.stderr.write(result.stderr);
+}
+
+if (
+  result.status === 2 &&
+  /No files matching the pattern/.test(result.stderr || '')
+) {
+  console.log('No files to lint');
+  process.exit(0);
+}
+
+if (result.error) {
+  throw result.error;
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
- add a helper script that re-runs eslint and only tolerates the "No files matching" exit
- update Storybook, design tokens, and icons lint scripts to use the helper so real failures surface

## Testing
- pnpm --filter @dynui/icons lint *(fails: missing @stylistic/eslint-plugin dependency, confirms lint errors propagate)*

------
https://chatgpt.com/codex/tasks/task_e_68fd887db044832494c28886ac074729