### PR TITLE
fix: ensure lint scripts fail on ESLint errors

### DIFF
--- a/tools/run-eslint-if-files.cjs
+++ b/tools/run-eslint-if-files.cjs
@@ -22,9 +22,11 @@ if (result.stderr) {
   process.stderr.write(result.stderr);
 }
 
+const noFilesPattern = /No files matching the pattern/;
+
 if (
   result.status === 2 &&
-  /No files matching the pattern/.test(result.stderr || '')
+  [result.stdout, result.stderr].some((stream) => noFilesPattern.test(stream || ''))
 ) {
   console.log('No files to lint');
   process.exit(0);


### PR DESCRIPTION
## Summary
- update the no-files guard to check both stdout and stderr for ESLint's "No files matching" message so empty globs are tolerated again

## Testing
- not run (helper script change only)


------
https://chatgpt.com/codex/tasks/task_e_68fd8d3a1680832488188f977dd842da