### PR TITLE
fix: simplify lint config dependencies

### DIFF
--- a/tools/eslint-ts-parser.js
+++ b/tools/eslint-ts-parser.js
@@ -10,12 +10,20 @@ const espree = require(espreePath)
 
 const DEFAULT_ECMA_VERSION = 2023
 
+function isTSXFile(filePath) {
+  if (!filePath) return false
+
+  const normalizedPath = filePath.toLowerCase()
+  return normalizedPath.endsWith('.tsx')
+}
+
 function createParserOptions(options = {}) {
   const ecmaVersion = options.ecmaVersion ?? DEFAULT_ECMA_VERSION
   const sourceType = options.sourceType ?? 'module'
+  const jsxEnabled = options.ecmaFeatures?.jsx ?? isTSXFile(options.filePath)
   const ecmaFeatures = {
-    jsx: true,
-    ...(options.ecmaFeatures ?? {})
+    ...(options.ecmaFeatures ?? {}),
+    jsx: jsxEnabled
   }
 
   return {


### PR DESCRIPTION
## Summary
- gate the custom TypeScript parser's JSX mode on `.tsx` file paths so plain `.ts` files parse without JSX

## Testing
- pnpm -C packages/design-tokens lint

------
https://chatgpt.com/codex/tasks/task_e_68fe33e1406c83248ccd796e19c955e2