### PR TITLE
fix: restore transpile-based ESLint TypeScript parser

### DIFF
--- a/tools/eslint-ts-parser.js
+++ b/tools/eslint-ts-parser.js
@@ -1,10 +1,12 @@
 import { createRequire } from 'node:module'
 import path from 'node:path'
+import ts from 'typescript'
+
 const require = createRequire(import.meta.url)
 const eslintPackagePath = require.resolve('eslint/package.json')
 const eslintDir = path.dirname(eslintPackagePath)
-const tsParserPath = require.resolve('@typescript-eslint/parser', { paths: [eslintDir] })
-const tsParser = require(tsParserPath)
+const espreePath = require.resolve('espree', { paths: [eslintDir] })
+const espree = require(espreePath)
 
 const DEFAULT_ECMA_VERSION = 2023
 
@@ -28,23 +30,43 @@ function createParserOptions(options = {}) {
   }
 }
 
+function transpileTypeScript(code, options = {}) {
+  const fileName = options.filePath ?? (options.ecmaFeatures?.jsx ? 'inline.tsx' : 'inline.ts')
+  const compilerOptions = {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.ESNext,
+    jsx: options.ecmaFeatures?.jsx ? ts.JsxEmit.Preserve : ts.JsxEmit.None,
+    useDefineForClassFields: true,
+    importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
+    preserveValueImports: true
+  }
+
+  return ts.transpileModule(code, {
+    fileName,
+    compilerOptions,
+    reportDiagnostics: false
+  }).outputText
+}
+
 export function parse(code, options = {}) {
   return parseForESLint(code, options).ast
 }
 
 export function parseForESLint(code, options = {}) {
-  const baseParserOptions = createParserOptions(options)
-  const parserOptions = {
-    ...options,
-    ...baseParserOptions,
-    ecmaFeatures: baseParserOptions.ecmaFeatures,
-    loc: true,
-    range: true,
-    tokens: true,
-    comment: true
-  }
+  const parserOptions = createParserOptions(options)
+  const transpiled = transpileTypeScript(code, parserOptions)
+  const ast = espree.parse(transpiled, parserOptions)
 
-  return tsParser.parseForESLint(code, parserOptions)
+  return {
+    ast,
+    services: {
+      transpiledText: transpiled
+    },
+    scopeManager: null,
+    visitorKeys: null,
+    tokens: ast.tokens,
+    comments: ast.comments
+  }
 }
 
 export default {


### PR DESCRIPTION
## Summary
- restore the transpile-to-JS parsing pipeline so ESLint receives a populated AST for TypeScript sources
- resolve Espree from ESLint's install location to keep behavior aligned with upstream ESLint expectations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe4610910c8324b0e8226601bcd0b6