### PR TITLE
fix: restore TypeScript parser usage

### DIFF
--- a/tools/eslint-ts-parser.js
+++ b/tools/eslint-ts-parser.js
@@ -1,12 +1,10 @@
 import { createRequire } from 'node:module'
 import path from 'node:path'
-import ts from 'typescript'
-
 const require = createRequire(import.meta.url)
 const eslintPackagePath = require.resolve('eslint/package.json')
 const eslintDir = path.dirname(eslintPackagePath)
-const espreePath = require.resolve('espree', { paths: [eslintDir] })
-const espree = require(espreePath)
+const tsParserPath = require.resolve('@typescript-eslint/parser', { paths: [eslintDir] })
+const tsParser = require(tsParserPath)
 
 const DEFAULT_ECMA_VERSION = 2023
 
@@ -30,43 +28,23 @@ function createParserOptions(options = {}) {
   }
 }
 
-function transpileTypeScript(code, options = {}) {
-  const fileName = options.filePath ?? (options.ecmaFeatures?.jsx ? 'inline.tsx' : 'inline.ts')
-  const compilerOptions = {
-    target: ts.ScriptTarget.ES2022,
-    module: ts.ModuleKind.ESNext,
-    jsx: options.ecmaFeatures?.jsx ? ts.JsxEmit.Preserve : ts.JsxEmit.None,
-    useDefineForClassFields: true,
-    importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
-    preserveValueImports: true
-  }
-
-  return ts.transpileModule(code, {
-    fileName,
-    compilerOptions,
-    reportDiagnostics: false
-  }).outputText
-}
-
 export function parse(code, options = {}) {
   return parseForESLint(code, options).ast
 }
 
 export function parseForESLint(code, options = {}) {
-  const parserOptions = createParserOptions(options)
-  const transpiled = transpileTypeScript(code, parserOptions)
-  const ast = espree.parse(transpiled, parserOptions)
-
-  return {
-    ast,
-    services: {
-      transpiledText: transpiled
-    },
-    scopeManager: null,
-    visitorKeys: null,
-    tokens: ast.tokens,
-    comments: ast.comments
+  const baseParserOptions = createParserOptions(options)
+  const parserOptions = {
+    ...options,
+    ...baseParserOptions,
+    ecmaFeatures: baseParserOptions.ecmaFeatures,
+    loc: true,
+    range: true,
+    tokens: true,
+    comment: true
   }
+
+  return tsParser.parseForESLint(code, parserOptions)
 }
 
 export default {


### PR DESCRIPTION
## Summary
- resolve `@typescript-eslint/parser` from ESLint's installation directory again
- delegate `parseForESLint` to the TypeScript parser so ESLint analyses the original TypeScript AST

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fe495eea008324a6f1e1728db011ea