### PR TITLE
Fix: recover TSX file path from ESLint context

### DIFF
--- a/tools/eslint-ts-parser.js
+++ b/tools/eslint-ts-parser.js
@@ -80,8 +80,8 @@ export function parse(code, options = {}) {
   return parseForESLint(code, options).ast
 }
 
-export function parseForESLint(code, options = {}) {
-  const filePath = extractFilePath(options)
+export function parseForESLint(code, options = {}, context) {
+  const filePath = extractFilePath(options) ?? extractFilePath(context)
   const parserOptions = createParserOptions(options, filePath)
   const transpiled = transpileTypeScript(code, { ...parserOptions, filePath })
   const ast = espree.parse(transpiled, parserOptions)


### PR DESCRIPTION
## Summary
- restore the `parseForESLint` context parameter
- recover the file path from ESLint context when parser options omit it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe49ca4ca48324abbe62547d004b77