### PR TITLE
feat: add class-based modifiers for DynContainer

### DIFF
--- a/src/types/components/dyn-container.types.ts
+++ b/src/types/components/dyn-container.types.ts
@@ -1,10 +1,34 @@
 import type { CSSProperties, ReactNode } from 'react';
 import type { SpacingValue } from '../common.types';
 
+export type DynContainerSize = 'sm' | 'md' | 'lg' | 'xl' | 'full';
+export type DynContainerSpacing = 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
 export interface DynContainerProps {
+  /**
+   * Maximum width of the container. String values matching design tokens
+   * will map to `dyn-container--max-{token}` classes. Other string values
+   * or numbers will be applied inline.
+   */
   maxWidth?: number | string;
-  p?: SpacingValue;
-  m?: SpacingValue;
+  /**
+   * Predefined container size helper (maps to `dyn-container--{size}`).
+   */
+  size?: DynContainerSize;
+  /**
+   * Whether the container should stretch to the full width.
+   */
+  fluid?: boolean;
+  /**
+   * Padding shorthand. Token strings map to BEM modifier classes; other
+   * values fall back to inline styles.
+   */
+  p?: SpacingValue | DynContainerSpacing;
+  /**
+   * Margin shorthand. Token strings map to BEM modifier classes; other
+   * values fall back to inline styles.
+   */
+  m?: SpacingValue | DynContainerSpacing;
   children?: ReactNode;
   className?: string;
   style?: CSSProperties;

--- a/src/ui/dyn-container.tsx
+++ b/src/ui/dyn-container.tsx
@@ -2,37 +2,73 @@ import { forwardRef } from 'react';
 import type { DynContainerProps } from '../types/components/dyn-container.types';
 import { getSpacingStyles, classNames } from '../utils';
 
-export const DynContainer = forwardRef<HTMLDivElement, DynContainerProps>(
-  ({ 
-    maxWidth,
-    p, 
-    m,
-    children,
-    className,
-    style,
-    'data-testid': testId,
-    ...props 
-  }, ref) => {
-    // Filter out undefined values for exactOptionalPropertyTypes
-    const spacingArgs: { p?: number | string; m?: number | string } = {};
-    if (p !== undefined) spacingArgs.p = p;
-    if (m !== undefined) spacingArgs.m = m;
-    
-    const spacingStyles = getSpacingStyles(spacingArgs);
+const SIZE_CLASS_VALUES = new Set(['sm', 'md', 'lg', 'xl', 'full']);
+const MAX_WIDTH_CLASS_VALUES = new Set(['xs', 'sm', 'md', 'lg', 'xl', 'full']);
+const SPACING_CLASS_VALUES = new Set(['none', 'xs', 'sm', 'md', 'lg', 'xl']);
 
-    const combinedStyle = {
-      ...spacingStyles,
-      maxWidth: maxWidth !== undefined ? 
-        (typeof maxWidth === 'string' ? maxWidth : `${maxWidth}px`) : undefined,
-      ...style
-    };
+export const DynContainer = forwardRef<HTMLDivElement, DynContainerProps>(
+  (
+    {
+      maxWidth,
+      size,
+      fluid,
+      p,
+      m,
+      children,
+      className,
+      style,
+      'data-testid': testId,
+      ...props
+    },
+    ref
+  ) => {
+    const spacingArgs: { p?: number | string; m?: number | string } = {};
+    const spacingClasses: Array<string | undefined> = [];
+
+    if (typeof p === 'string' && SPACING_CLASS_VALUES.has(p)) {
+      spacingClasses.push(`dyn-container--p-${p}`);
+    } else if (p !== undefined) {
+      spacingArgs.p = p;
+    }
+
+    if (typeof m === 'string' && SPACING_CLASS_VALUES.has(m)) {
+      spacingClasses.push(`dyn-container--m-${m}`);
+    } else if (m !== undefined) {
+      spacingArgs.m = m;
+    }
+
+    const inlineStyles = Object.keys(spacingArgs).length
+      ? getSpacingStyles(spacingArgs)
+      : {};
+
+    const shouldInlineMaxWidth =
+      maxWidth !== undefined &&
+      !(typeof maxWidth === 'string' && MAX_WIDTH_CLASS_VALUES.has(maxWidth));
+
+    if (shouldInlineMaxWidth) {
+      inlineStyles.maxWidth =
+        typeof maxWidth === 'number' ? `${maxWidth}px` : maxWidth;
+    }
+
+    const mergedStyle = style
+      ? { ...inlineStyles, ...style }
+      : Object.keys(inlineStyles).length ? inlineStyles : undefined;
 
     return (
       <div
         {...props}
         ref={ref}
-        className={classNames('dyn-container', className)}
-        style={combinedStyle}
+        className={classNames(
+          'dyn-container',
+          size && SIZE_CLASS_VALUES.has(size) ? `dyn-container--${size}` : undefined,
+          typeof maxWidth === 'string' && MAX_WIDTH_CLASS_VALUES.has(maxWidth)
+            ? `dyn-container--max-${maxWidth}`
+            : undefined,
+          fluid && 'dyn-container--fluid',
+          ...spacingClasses,
+          className
+        )}
+        style={mergedStyle}
         data-testid={testId}
       >
         {children}

--- a/stories/DynContainer.stories.tsx
+++ b/stories/DynContainer.stories.tsx
@@ -18,7 +18,15 @@ const meta: Meta<typeof DynContainer> = {
     },
     maxWidth: {
       control: { type: 'select' },
-      options: ['xs', 'sm', 'md', 'lg', 'xl']
+      options: ['xs', 'sm', 'md', 'lg', 'xl', 'full']
+    },
+    p: {
+      control: { type: 'select' },
+      options: ['none', 'xs', 'sm', 'md', 'lg', 'xl']
+    },
+    m: {
+      control: { type: 'select' },
+      options: ['none', 'xs', 'sm', 'md', 'lg', 'xl']
     }
   }
 }


### PR DESCRIPTION
## Summary
- extend DynContainer props with size, fluid and spacing token helpers
- derive BEM modifier classes for size, max-width and spacing while preserving inline overrides
- document spacing options in Storybook controls

## Testing
- pnpm exec vitest run tests/components/dyn-container.test.tsx *(fails: missing react/jsx-dev-runtime dependency in test runner)*

------
https://chatgpt.com/codex/tasks/task_e_68fe5e17f1d08324838eda408375b250