### PR TITLE
fix: skip max width modifier for fluid container

### DIFF
--- a/src/ui/dyn-container.tsx
+++ b/src/ui/dyn-container.tsx
@@ -61,7 +61,9 @@ export const DynContainer = forwardRef<HTMLDivElement, DynContainerProps>(
         className={classNames(
           'dyn-container',
           size && SIZE_CLASS_VALUES.has(size) ? `dyn-container--${size}` : undefined,
-          typeof maxWidth === 'string' && MAX_WIDTH_CLASS_VALUES.has(maxWidth)
+          !fluid &&
+          typeof maxWidth === 'string' &&
+          MAX_WIDTH_CLASS_VALUES.has(maxWidth)
             ? `dyn-container--max-${maxWidth}`
             : undefined,
           fluid && 'dyn-container--fluid',


### PR DESCRIPTION
## Summary
- prevent the DynContainer from receiving a max-width modifier when the fluid flag is enabled

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe6367b6bc832495da2b990f4f7ee8