### PR TITLE
fix: avoid max width constraints for fluid container

### DIFF
--- a/src/ui/dyn-container.tsx
+++ b/src/ui/dyn-container.tsx
@@ -42,6 +42,7 @@ export const DynContainer = forwardRef<HTMLDivElement, DynContainerProps>(
       : {};
 
     const shouldInlineMaxWidth =
+      !fluid &&
       maxWidth !== undefined &&
       !(typeof maxWidth === 'string' && MAX_WIDTH_CLASS_VALUES.has(maxWidth));
 


### PR DESCRIPTION
## Summary
- skip applying inline max-width styles when the container is marked as fluid

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe6498303883248c353a08297ef42a