### PR TITLE
Adjust DynContainer tests and stories after modifier revert

### DIFF
--- a/stories/DynContainer.stories.tsx
+++ b/stories/DynContainer.stories.tsx
@@ -12,13 +12,17 @@ const meta: Meta<typeof DynContainer> = {
     }
   },
   argTypes: {
-    size: {
-      control: { type: 'select' },
-      options: ['sm', 'md', 'lg', 'xl', 'full']
-    },
     maxWidth: {
-      control: { type: 'select' },
-      options: ['xs', 'sm', 'md', 'lg', 'xl']
+      control: { type: 'text' },
+      description: 'Sets a maximum width for the container (number will be treated as pixels).'
+    },
+    p: {
+      control: { type: 'text' },
+      description: 'Padding applied to the container. Numbers are treated as pixels.'
+    },
+    m: {
+      control: { type: 'text' },
+      description: 'Margin applied to the container. Numbers are treated as pixels.'
     }
   }
 }
@@ -39,42 +43,29 @@ export const Default: Story = {
   }
 }
 
-export const Sizes: Story = {
+export const MaxWidthExamples: Story = {
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
-      <DynContainer size="sm">
-        <div style={{ background: '#e3f2fd', padding: '1rem' }}>Small Container</div>
+      <DynContainer maxWidth={360}>
+        <div style={{ background: '#e3f2fd', padding: '1rem' }}>360px max width</div>
       </DynContainer>
-      <DynContainer size="md">
-        <div style={{ background: '#f3e5f5', padding: '1rem' }}>Medium Container</div>
+      <DynContainer maxWidth="48rem">
+        <div style={{ background: '#f3e5f5', padding: '1rem' }}>48rem max width</div>
       </DynContainer>
-      <DynContainer size="lg">
-        <div style={{ background: '#e8f5e8', padding: '1rem' }}>Large Container</div>
-      </DynContainer>
-      <DynContainer size="xl">
-        <div style={{ background: '#fff3e0', padding: '1rem' }}>Extra Large Container</div>
+      <DynContainer>
+        <div style={{ background: '#e8f5e8', padding: '1rem' }}>No max width</div>
       </DynContainer>
     </div>
   )
 }
 
-export const WithPadding: Story = {
+export const WithSpacing: Story = {
   args: {
-    p: 'lg',
+    p: 32,
+    m: '2rem',
     children: (
       <div style={{ background: '#f5f5f5', minHeight: '200px' }}>
-        Container with large padding
-      </div>
-    )
-  }
-}
-
-export const Fluid: Story = {
-  args: {
-    fluid: true,
-    children: (
-      <div style={{ background: '#e1f5fe', padding: '1rem' }}>
-        Fluid container takes full width
+        Container with padding and margin applied via inline styles
       </div>
     )
   }

--- a/tests/components/dyn-container.test.tsx
+++ b/tests/components/dyn-container.test.tsx
@@ -13,35 +13,25 @@ describe('DynContainer', () => {
     expect(screen.getByText('Content')).toBeInTheDocument()
   })
 
-  it('applies size classes', () => {
+  it('applies max width style when provided', () => {
     render(
-      <DynContainer size="sm" data-testid="container">
+      <DynContainer maxWidth={640} data-testid="container">
         Content
       </DynContainer>
     )
-    
-    expect(screen.getByTestId('container')).toHaveClass('dyn-container--sm')
+
+    expect(screen.getByTestId('container')).toHaveStyle({ maxWidth: '640px' })
   })
 
-  it('handles fluid layout', () => {
+  it('applies spacing styles for padding and margin', () => {
     render(
-      <DynContainer fluid data-testid="container">
+      <DynContainer p={24} m="3rem" data-testid="container">
         Content
       </DynContainer>
     )
-    
-    expect(screen.getByTestId('container')).toHaveClass('dyn-container--fluid')
-  })
 
-  it('applies spacing', () => {
-    render(
-      <DynContainer p="lg" m="md" data-testid="container">
-        Content
-      </DynContainer>
-    )
-    
     const container = screen.getByTestId('container')
-    expect(container).toHaveClass('dyn-container--p-lg')
-    expect(container).toHaveClass('dyn-container--m-md')
+    expect(container).toHaveStyle({ padding: '24px' })
+    expect(container).toHaveStyle({ margin: '3rem' })
   })
 })


### PR DESCRIPTION
## Summary
- rewrite DynContainer tests to validate maxWidth and spacing styles now provided by inline styles
- update Storybook controls and examples to reflect the simplified DynContainer props surface

## Testing
- pnpm vitest run tests/components/dyn-container.test.tsx *(fails: Failed to resolve import "react/jsx-dev-runtime")*

------
https://chatgpt.com/codex/tasks/task_e_68fe65a66cfc83249ed8559611fbad47