### PR TITLE
fix: add design tokens workspace dependency for theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "build:storybook": "cd apps/storybook && pnpm build:storybook",
     "playground": "pnpm --filter playground dev"
   },
+  "dependencies": {
+    "@dynui/design-tokens": "workspace:*"
+  },
   "devDependencies": {
     "@axe-core/react": "catalog:",
     "@storybook/addon-a11y": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,10 @@ catalogs:
 importers:
 
   .:
+    dependencies:
+      '@dynui/design-tokens':
+        specifier: workspace:*
+        version: link:packages/design-tokens
     devDependencies:
       '@axe-core/react':
         specifier: 'catalog:'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "./tools/build-config/tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@dynui/design-tokens": ["packages/design-tokens/src"]
+    }
+  },
   "exclude": [
     "./dist",
     "./build",


### PR DESCRIPTION
## Summary
- add the @dynui/design-tokens workspace dependency required by the default theme
- configure the root tsconfig path alias so TypeScript resolves the token module

## Testing
- pnpm exec tsc -p tsconfig.json *(fails: existing parse error in src/ui/dyn-field-container.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68fe6601dd3883249e810ac2d9ce4d37