### PR TITLE
Restore @typescript-eslint parser filePath context handling

### DIFF
--- a/tools/eslint-ts-parser.js
+++ b/tools/eslint-ts-parser.js
@@ -48,6 +48,7 @@ function createParserOptions(options = {}, filePath) {
     ecmaVersion,
     sourceType,
     ecmaFeatures,
+    filePath: resolvedFilePath,
     allowHashBang: options.allowHashBang ?? true,
     loc: true,
     range: true,
@@ -56,16 +57,18 @@ function createParserOptions(options = {}, filePath) {
   }
 }
 
-export function parse(code, options = {}) {
-  return parseForESLint(code, options).ast
+export function parse(code, options = {}, context) {
+  return parseForESLint(code, options, context).ast
 }
 
-export function parseForESLint(code, options = {}) {
-  const baseParserOptions = createParserOptions(options)
+export function parseForESLint(code, options = {}, context) {
+  const filePath = extractFilePath(context)
+  const baseParserOptions = createParserOptions(options, filePath)
   const parserOptions = {
     ...options,
     ...baseParserOptions,
     ecmaFeatures: baseParserOptions.ecmaFeatures,
+    filePath: baseParserOptions.filePath,
     loc: true,
     range: true,
     tokens: true,


### PR DESCRIPTION
## Summary
- derive the file path from the ESLint parser context when building parser options
- ensure the inferred filePath is passed through so TSX files enable JSX automatically

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe6bed0e748324b1f9b5c6e93bef45