### PR TITLE
Fix optional data-testids in DynMenu components

### DIFF
--- a/src/ui/dyn-menu.tsx
+++ b/src/ui/dyn-menu.tsx
@@ -37,7 +37,7 @@ export const DynMenu = forwardRef<HTMLDivElement, DynMenuProps>(
         ref={ref}
         role="menu"
         className={classNames('dyn-menu', `dyn-menu--${orientation}`, className)}
-        data-testid={testId}
+        {...(testId !== undefined ? { 'data-testid': testId } : {})}
       >
         {mappedItems}
         {React.Children.map(children, (child, index) => {
@@ -77,7 +77,7 @@ export const DynMenuItem = forwardRef<HTMLElement, DynMenuItemProps>(
           ref={ref as React.ForwardedRef<HTMLDivElement>}
           role="separator"
           className={classNames('dyn-menu-divider', className)}
-          data-testid={testId}
+          {...(testId !== undefined ? { 'data-testid': testId } : {})}
           aria-hidden="true"
         />
       );
@@ -107,7 +107,7 @@ export const DynMenuItem = forwardRef<HTMLElement, DynMenuItemProps>(
         disabled={disabled}
         className={classNames('dyn-menu-item', disabled && 'dyn-menu-item--disabled', className)}
         onClick={handleClick}
-        data-testid={testId}
+        {...(testId !== undefined ? { 'data-testid': testId } : {})}
       >
         {label}
         {shortcut ? <span className="dyn-menu-item__shortcut">{shortcut}</span> : null}


### PR DESCRIPTION
## Summary
- avoid passing undefined `data-testid` values when rendering DynMenu containers and items so that builds succeed with exact optional property types

## Testing
- pnpm --filter @dynui/core build *(fails: TS2307 cannot find module '@dynui/design-tokens')*

------
https://chatgpt.com/codex/tasks/task_e_68fe76c9c7908324a63b7bdc3a42384c