### PR TITLE
Preserve DynMenu divider props

### DIFF
--- a/src/ui/dyn-menu.tsx
+++ b/src/ui/dyn-menu.tsx
@@ -91,6 +91,7 @@ export const DynMenuItem = forwardRef<HTMLElement, DynMenuItemProps>(
   }, ref) => {
     if (item?.type === 'divider') {
       const menuSeparatorProps: MenuSeparatorProps = {
+        ...restProps,
         className: classNames('dyn-menu-divider', className)
       };
 


### PR DESCRIPTION
## Summary
- forward any remaining divider attributes when rendering MenuSeparator so custom styles and aria hooks are preserved

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68fe7aace0f48324aae2e8e543b205dd