### PR TITLE
Enhance DynContainer token handling

### DIFF
--- a/src/types/components/dyn-container.types.ts
+++ b/src/types/components/dyn-container.types.ts
@@ -1,12 +1,36 @@
-import type { CSSProperties, ReactNode } from 'react';
-import type { SpacingValue } from '../common.types';
+import type { HTMLAttributes } from 'react';
 
-export interface DynContainerProps {
-  maxWidth?: number | string;
-  p?: SpacingValue;
-  m?: SpacingValue;
-  children?: ReactNode;
-  className?: string;
-  style?: CSSProperties;
+export type DynContainerSize = 'sm' | 'md' | 'lg';
+
+export type DynContainerMaxWidthToken = 'sm' | 'md' | 'lg' | 'xl';
+
+export type DynContainerSpacingToken =
+  | 'none'
+  | 'xxs'
+  | 'xs'
+  | 'sm'
+  | 'md'
+  | 'lg'
+  | 'xl'
+  | '2xl'
+  | '3xl'
+  | '0'
+  | '0.5'
+  | '1'
+  | '1.5'
+  | '2'
+  | '3'
+  | '4'
+  | '6'
+  | '8'
+  | '12'
+  | '16';
+
+export interface DynContainerProps extends HTMLAttributes<HTMLDivElement> {
+  size?: DynContainerSize;
+  fluid?: boolean;
+  maxWidth?: number | DynContainerMaxWidthToken | (string & {});
+  p?: number | DynContainerSpacingToken | (string & {});
+  m?: number | DynContainerSpacingToken | (string & {});
   'data-testid'?: string;
 }

--- a/src/ui/dyn-container.tsx
+++ b/src/ui/dyn-container.tsx
@@ -1,17 +1,56 @@
 import { forwardRef } from 'react';
-import type { DynContainerProps } from '../types/components/dyn-container.types';
+import type {
+  DynContainerMaxWidthToken,
+  DynContainerProps,
+  DynContainerSize,
+  DynContainerSpacingToken,
+} from '../types/components/dyn-container.types';
 import { getSpacingStyles, classNames } from '../utils';
 
+const SPACING_CLASS_VALUES = new Set<DynContainerSpacingToken>([
+  'none',
+  'xxs',
+  'xs',
+  'sm',
+  'md',
+  'lg',
+  'xl',
+  '2xl',
+  '3xl',
+  '0',
+  '0.5',
+  '1',
+  '1.5',
+  '2',
+  '3',
+  '4',
+  '6',
+  '8',
+  '12',
+  '16',
+]);
+
+const MAX_WIDTH_CLASS_VALUES = new Set<DynContainerMaxWidthToken>([
+  'sm',
+  'md',
+  'lg',
+  'xl',
+]);
+
+const SIZE_CLASS_VALUES = new Set<DynContainerSize>(['sm', 'md', 'lg']);
+
 export const DynContainer = forwardRef<HTMLDivElement, DynContainerProps>(
-  ({ 
+  ({
     maxWidth,
-    p, 
+    p,
     m,
+    size,
+    fluid,
     children,
     className,
     style,
     'data-testid': testId,
-    ...props 
+    ...props
   }, ref) => {
     // Filter out undefined values for exactOptionalPropertyTypes
     const spacingArgs: { p?: number | string; m?: number | string } = {};


### PR DESCRIPTION
## Summary
- extend DynContainer props to cover native div attributes, size, and design-token unions
- add token validation sets in the DynContainer component and destructure the new props
- ensure inline styles are only applied when spacing or maxWidth values fall outside token sets

## Testing
- pnpm typecheck
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68fe8131c92c83248dc70f5b2bf06782