### PR TITLE
Configure Vitest coverage and React plugin

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  plugins: [react()],
   test: {
     environment: 'jsdom',
     globals: true,
@@ -12,7 +14,23 @@ export default defineConfig({
       'packages/*/tests/**/*.test.tsx'
     ],
     coverage: {
-      provider: 'v8'
+      provider: 'v8',
+      reporter: ['text', 'json', 'html', 'lcov'],
+      thresholds: {
+        global: {
+          statements: 80,
+          branches: 80,
+          functions: 80,
+          lines: 80
+        }
+      },
+      exclude: [
+        'node_modules/**',
+        'dist/**',
+        '**/*.d.ts',
+        '**/*.config.{js,ts}',
+        'tests/setup.ts'
+      ]
     }
   }
 })


### PR DESCRIPTION
## Summary
- enable the React plugin in the root Vitest configuration so tests can leverage JSX transformation
- configure coverage reporters, global thresholds, and exclusions to align with the new coverage expectations

## Testing
- ⚠️ `pnpm test --coverage` *(fails in this environment because Turbo rejects forwarding the --coverage flag)*


------
https://chatgpt.com/codex/tasks/task_e_68fe945f5c5c832488e330e8068d26b5