### PR TITLE
fix: ensure husky pre-commit hook runs properly

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -13,7 +13,7 @@ pnpm lint || (echo "❌ ESLint errors found" && exit 1)
 pnpm format:check || (echo "❌ Prettier formatting issues found" && exit 1)
 
 # Unit tests for changed files
-pnpm test --run --changed || (echo "❌ Tests failing" && exit 1)
+pnpm test -- --run --changed || (echo "❌ Tests failing" && exit 1)
 
 echo "✅ Pre-commit checks passed!"
 

--- a/tools/husky/bin/husky.js
+++ b/tools/husky/bin/husky.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
 import { chmodSync, existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
@@ -37,6 +38,19 @@ function installHooks() {
   }
 
   chmodSync(bootstrapScript, 0o755)
+
+  const result = spawnSync('git', ['config', 'core.hooksPath', '.husky'])
+
+  if (result.status !== 0) {
+    const errorOutput = result.stderr?.toString().trim()
+
+    if (errorOutput) {
+      console.warn(`husky - failed to set Git hooks path: ${errorOutput}`)
+    } else {
+      console.warn('husky - failed to set Git hooks path')
+    }
+  }
+
   console.log('husky - hooks installed')
 }
 


### PR DESCRIPTION
## Summary
- forward pre-commit test flags through pnpm so changed-file tests run
- configure Git's hooksPath during the custom husky install step and warn if it fails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe9a704768832481dbd89d8ef1ec94