### PR TITLE
Fix coverage flag forwarding in quality gates workflow

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Run Unit Tests with Coverage
         run: |
           set -o pipefail
-          pnpm test -- --coverage --silent | tee coverage-output.txt
+          pnpm test -- -- --coverage --silent | tee coverage-output.txt
       - name: Enforce Coverage Threshold (80%)
         run: |
           node <<'NODE'


### PR DESCRIPTION
## Summary
- ensure the unit test step in the quality gates workflow inserts the extra `--` so coverage flags are passed through to pnpm test

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe9c95c9448324ad310b8ef1c6e617