### PR TITLE
fix: ensure husky pre-commit hook runs properly

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -13,7 +13,7 @@ pnpm lint || (echo "❌ ESLint errors found" && exit 1)
 pnpm format:check || (echo "❌ Prettier formatting issues found" && exit 1)
 
 # Unit tests for changed files
-pnpm test -- --run --changed || (echo "❌ Tests failing" && exit 1)
+pnpm test -- -- --run --changed || (echo "❌ Tests failing" && exit 1)
 
 echo "✅ Pre-commit checks passed!"
 


### PR DESCRIPTION
## Summary
- add a second `--` when forwarding vitest flags through turbo so `--run` reaches the test runner

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fe9c9b2cb4832499f7e9b487067a07