### PR TITLE
Fix turbo pass-through in pre-commit tests

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -13,7 +13,7 @@ pnpm lint || (echo "❌ ESLint errors found" && exit 1)
 pnpm format:check || (echo "❌ Prettier formatting issues found" && exit 1)
 
 # Unit tests for changed files
-pnpm test -- --run --changed || (echo "❌ Tests failing" && exit 1)
+pnpm test -- -- --run --changed || (echo "❌ Tests failing" && exit 1)
 
 echo "✅ Pre-commit checks passed!"
 


### PR DESCRIPTION
## Summary
- ensure the pre-commit test step forwards flags through turbo by adding a second separator

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe9c9cfc148324b99869331b912ed9