### PR TITLE
Fix coverage flag forwarding in quality gates workflow

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Run Unit Tests with Coverage
         run: |
           set -o pipefail
-          pnpm test -- -- --coverage --silent | tee coverage-output.txt
+          pnpm test -- --coverage --silent | tee coverage-output.txt
       - name: Enforce Coverage Threshold (80%)
         run: |
           node <<'NODE'

--- a/tools/run-turbo-task.js
+++ b/tools/run-turbo-task.js
@@ -16,7 +16,27 @@ if (isRunningInsideTurbo) {
 }
 
 const args = process.argv.slice(2)
-const result = spawnSync('turbo', args, {
+
+if (args.length === 0) {
+  console.error('No turbo task specified.')
+  process.exit(1)
+}
+
+const [task, ...rest] = args
+
+const turboArgs = [task]
+
+if (rest.length > 0) {
+  if (rest[0] === '--turbo') {
+    turboArgs.push(...rest.slice(1))
+  } else if (rest.includes('--')) {
+    turboArgs.push(...rest)
+  } else {
+    turboArgs.push('--', ...rest)
+  }
+}
+
+const result = spawnSync('turbo', turboArgs, {
   stdio: 'inherit',
   env: process.env
 })


### PR DESCRIPTION
## Summary
- teach the turbo task helper to insert `--` when forwarding flags to the underlying package scripts
- trim the quality gates workflow back to `pnpm test -- --coverage --silent` now that passthrough arguments are handled centrally

## Testing
- pnpm typecheck
- pnpm lint
- pnpm format:check

------
https://chatgpt.com/codex/tasks/task_e_68fe9f5ee5c48324b80dc5f9e0b46a10