### PR TITLE
Fix pre-commit tests to run Vitest suites

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -13,7 +13,7 @@ pnpm lint || (echo "❌ ESLint errors found" && exit 1)
 pnpm format:check || (echo "❌ Prettier formatting issues found" && exit 1)
 
 # Unit tests for changed files
-pnpm test -- -- --run --changed || (echo "❌ Tests failing" && exit 1)
+pnpm test -- -- --changed || (echo "❌ Tests failing" && exit 1)
 
 echo "✅ Pre-commit checks passed!"
 


### PR DESCRIPTION
## Summary
- remove the redundant `--run` flag from the pre-commit test command so Vitest executes suites correctly when using `--changed`

## Testing
- `pnpm test -- -- --changed` *(fails: existing Vitest configuration resolution error in @dynui/core)*

------
https://chatgpt.com/codex/tasks/task_e_68fea2d975208324a359fadcd84c00eb