### PR TITLE
Fix turbo task argument forwarding

### DIFF
--- a/tools/run-turbo-task.js
+++ b/tools/run-turbo-task.js
@@ -29,10 +29,18 @@ const turboArgs = [task]
 if (rest.length > 0) {
   if (rest[0] === '--turbo') {
     turboArgs.push(...rest.slice(1))
-  } else if (rest.includes('--')) {
-    turboArgs.push(...rest)
   } else {
-    turboArgs.push('--', ...rest)
+    const separatorIndex = rest.indexOf('--')
+
+    if (separatorIndex === -1) {
+      turboArgs.push(...rest)
+    } else {
+      turboArgs.push(
+        ...rest.slice(0, separatorIndex),
+        '--',
+        ...rest.slice(separatorIndex + 1)
+      )
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- stop automatically prefixing turbo invocations with `--` when no task separator is provided
- continue honoring the `--turbo` escape hatch while allowing explicit `--` to forward arguments to the task command

## Testing
- ✅ `node ./tools/run-turbo-task.js typecheck`
- ✅ `node ./tools/run-turbo-task.js lint`
- ❌ `pnpm format:check` *(fails because Prettier cannot parse existing repository files)*
- ❌ `node ./tools/run-turbo-task.js test "--" "--run" "--changed"` *(fails because Vitest cannot resolve packages/core/vitest.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68fea48fb10c8324994f9efdc94e9d2d