### PR TITLE
fix: import Storybook types from @storybook/react

### DIFF
--- a/apps/storybook/.storybook/preview.ts
+++ b/apps/storybook/.storybook/preview.ts
@@ -1,4 +1,4 @@
-import type { Preview } from '@storybook/react-vite'
+import type { Preview } from '@storybook/react'
 import { ThemeProvider } from '@dynui/core'
 import '@dynui/core/styles'
 

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@storybook/addon-a11y": "catalog:",
     "@storybook/addon-essentials": "catalog:",
+    "@storybook/react": "catalog:",
     "@storybook/react-vite": "catalog:",
     "@storybook/test": "catalog:",
     "@storybook/test-runner": "catalog:",

--- a/apps/storybook/stories/dyn-select.stories.tsx
+++ b/apps/storybook/stories/dyn-select.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { userEvent, within, expect } from '@storybook/test'
 import { DynSelect } from '@dynui/core'
 import type { DynSelectRef } from '@dynui/core'

--- a/apps/storybook/stories/dyn-tabs.stories.tsx
+++ b/apps/storybook/stories/dyn-tabs.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynTabs, DynTab, DynTabPanel } from '@dynui/core'
 
 const meta: Meta<typeof DynTabs> = {

--- a/apps/storybook/stories/dyn-textarea.stories.tsx
+++ b/apps/storybook/stories/dyn-textarea.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynTextArea } from '@dynui/core'
 
 const meta: Meta<typeof DynTextArea> = {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@storybook/addon-a11y": "catalog:",
     "@storybook/addon-docs": "catalog:",
     "@storybook/addon-essentials": "catalog:",
+    "@storybook/react": "catalog:",
     "@storybook/react-vite": "catalog:",
     "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     '@storybook/addon-essentials':
       specifier: ^8.3.5
       version: 8.6.14
+    '@storybook/react':
+      specifier: ^8.3.5
+      version: 8.6.14
     '@storybook/react-vite':
       specifier: ^8.3.5
       version: 8.6.14
@@ -117,6 +120,9 @@ importers:
       '@storybook/addon-essentials':
         specifier: 'catalog:'
         version: 8.6.14(@types/react@18.3.26)(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/react':
+        specifier: 'catalog:'
+        version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@8.6.14(prettier@3.6.2))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: 'catalog:'
         version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.52.5)(storybook@8.6.14(prettier@3.6.2))(typescript@5.9.3)(vite@5.4.21(@types/node@24.9.1))
@@ -251,6 +257,9 @@ importers:
       '@storybook/addon-essentials':
         specifier: 'catalog:'
         version: 8.6.14(@types/react@18.3.26)(storybook@8.6.14(prettier@3.6.2))
+      '@storybook/react':
+        specifier: 'catalog:'
+        version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: 'catalog:'
         version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.52.5)(storybook@8.6.14(prettier@3.6.2))(typescript@5.9.3)(vite@5.4.21(@types/node@24.9.1))

--- a/stories/DynBreadcrumb.stories.tsx
+++ b/stories/DynBreadcrumb.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynBreadcrumb } from '../src/ui/dyn-breadcrumb'
 
 const meta: Meta<typeof DynBreadcrumb> = {

--- a/stories/DynButton.stories.tsx
+++ b/stories/DynButton.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynButton } from '../src/ui/dyn-button'
 
 const meta: Meta<typeof DynButton> = {

--- a/stories/DynCheckbox.stories.tsx
+++ b/stories/DynCheckbox.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynCheckbox } from '../src/ui/dyn-checkbox'
 
 const meta: Meta<typeof DynCheckbox> = {

--- a/stories/DynContainer.stories.tsx
+++ b/stories/DynContainer.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynContainer } from '../src/ui/dyn-container'
 
 const meta: Meta<typeof DynContainer> = {

--- a/stories/DynIcon.stories.tsx
+++ b/stories/DynIcon.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynIcon } from '../src/ui/dyn-icon'
 
 const meta: Meta<typeof DynIcon> = {

--- a/stories/DynInput.stories.tsx
+++ b/stories/DynInput.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynInput } from '../src/ui/dyn-input'
 
 const meta: Meta<typeof DynInput> = {

--- a/stories/DynListView.stories.tsx
+++ b/stories/DynListView.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynListView } from '../src/ui/dyn-listview'
 
 const meta: Meta<typeof DynListView> = {

--- a/stories/DynMenu.Scenarios.stories.tsx
+++ b/stories/DynMenu.Scenarios.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynMenu } from '../src/ui/dyn-menu'
 
 const meta: Meta<typeof DynMenu> = {

--- a/stories/DynMenu.stories.tsx
+++ b/stories/DynMenu.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynMenu } from '../src/ui/dyn-menu'
 
 const meta: Meta<typeof DynMenu> = {

--- a/stories/DynModal.Scenarios.stories.tsx
+++ b/stories/DynModal.Scenarios.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynModal } from '../src/ui/dyn-modal'
 
 const meta: Meta<typeof DynModal> = {

--- a/stories/DynModal.stories.tsx
+++ b/stories/DynModal.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynModal } from '../src/ui/dyn-modal'
 import { useState } from 'react'
 

--- a/stories/DynRadioGroup.stories.tsx
+++ b/stories/DynRadioGroup.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynRadioGroup } from '../src/ui/dyn-radio'
 
 const meta: Meta<typeof DynRadioGroup> = {

--- a/stories/DynSelect.Scenarios.stories.tsx
+++ b/stories/DynSelect.Scenarios.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynSelect } from '../src/ui/dyn-select'
 
 const meta: Meta<typeof DynSelect> = {

--- a/stories/DynSelect.stories.tsx
+++ b/stories/DynSelect.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynSelect } from '../src/ui/dyn-select'
 
 const meta: Meta<typeof DynSelect> = {

--- a/stories/DynTable.Scenarios.stories.tsx
+++ b/stories/DynTable.Scenarios.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynTable } from '../src/ui/dyn-table'
 
 const meta: Meta<typeof DynTable> = {

--- a/stories/DynTable.stories.tsx
+++ b/stories/DynTable.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynTable } from '../src/ui/dyn-table'
 
 const meta: Meta<typeof DynTable> = {

--- a/stories/DynTabs.stories.tsx
+++ b/stories/DynTabs.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynTabs, DynTab, DynTabPanel } from '../src/ui/dyn-tabs'
 
 const meta: Meta<typeof DynTabs> = {

--- a/stories/DynTextArea.stories.tsx
+++ b/stories/DynTextArea.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynTextArea } from '../src/ui/dyn-textarea'
 
 const meta: Meta<typeof DynTextArea> = {

--- a/stories/DynTreeView.stories.tsx
+++ b/stories/DynTreeView.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynTreeView } from '../src/ui/dyn-tree'
 
 const meta: Meta<typeof DynTreeView> = {

--- a/stories/KitchenSink.stories.tsx
+++ b/stories/KitchenSink.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynButton } from '../src/ui/dyn-button'
 import { DynInput } from '../src/ui/dyn-input'
 import { DynSelect } from '../src/ui/dyn-select'

--- a/stories/forms/AccessibilityScenarios.stories.tsx
+++ b/stories/forms/AccessibilityScenarios.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react'
 import { DynInput } from '../../src/ui/dyn-input'
 import { DynButton } from '../../src/ui/dyn-button'
 import { DynSelect } from '../../src/ui/dyn-select'


### PR DESCRIPTION
## Summary
- restore Meta/StoryObj and Preview type imports in Storybook stories to use `@storybook/react`
- re-add `@storybook/react` to workspace dependencies so the types resolve without errors
- update the lockfile to capture the dependency changes

## Testing
- pnpm install --no-frozen-lockfile *(fails: registry requires authentication in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fec99046308324ac848805cba3c86d