### PR TITLE
Fix storybook stories glob paths

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,9 +1,21 @@
+import path from 'node:path'
+
 import type { StorybookConfig } from '@storybook/react-vite'
 
 const config: StorybookConfig = {
   stories: [
-    '../../../packages/*/src/**/*.stories.@(js|jsx|ts|tsx|mdx)',
-    '../../../stories/**/*.stories.@(js|jsx|ts|tsx|mdx)'
+    path.join(
+      path.resolve(__dirname, '..', '..', '..', 'packages'),
+      '*/src/**/*.stories.@(js|jsx|ts|tsx|mdx)'
+    ),
+    path.join(
+      path.resolve(__dirname, '..', '..', '..', 'stories'),
+      '**/*.stories.@(js|jsx|ts|tsx|mdx)'
+    ),
+    path.join(
+      path.resolve(__dirname, '..', 'stories'),
+      '**/*.stories.@(js|jsx|ts|tsx|mdx)'
+    )
   ],
   addons: [
     '@storybook/addon-essentials',


### PR DESCRIPTION
## Summary
- resolve storybook story globs to absolute paths so cross-platform builds locate stories
- include the local Storybook stories directory in the search patterns

## Testing
- pnpm -C apps/storybook storybook -- --smoke-test *(fails: storybook binary not available without installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68fed2ff7f6c8324b823fc1085ca1419