### PR TITLE
refactor: drop storybook react package

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "@storybook/addon-a11y": "catalog:",
     "@storybook/addon-essentials": "catalog:",
-    "@storybook/react": "catalog:",
     "@storybook/react-vite": "catalog:",
     "@storybook/test": "catalog:",
     "@storybook/test-runner": "catalog:",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@storybook/addon-a11y": "catalog:",
     "@storybook/addon-docs": "catalog:",
     "@storybook/addon-essentials": "catalog:",
-    "@storybook/react": "catalog:",
     "@storybook/react-vite": "catalog:",
     "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,9 +21,6 @@ catalogs:
     '@storybook/addon-essentials':
       specifier: ^8.3.5
       version: 8.6.14
-    '@storybook/react':
-      specifier: ^8.3.5
-      version: 8.6.14
     '@storybook/react-vite':
       specifier: ^8.3.5
       version: 8.6.14
@@ -120,9 +117,6 @@ importers:
       '@storybook/addon-essentials':
         specifier: 'catalog:'
         version: 8.6.14(@types/react@18.3.26)(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/react':
-        specifier: 'catalog:'
-        version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@8.6.14(prettier@3.6.2))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: 'catalog:'
         version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.52.5)(storybook@8.6.14(prettier@3.6.2))(typescript@5.9.3)(vite@5.4.21(@types/node@24.9.1))
@@ -257,9 +251,6 @@ importers:
       '@storybook/addon-essentials':
         specifier: 'catalog:'
         version: 8.6.14(@types/react@18.3.26)(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/react':
-        specifier: 'catalog:'
-        version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.6.2))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: 'catalog:'
         version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.52.5)(storybook@8.6.14(prettier@3.6.2))(typescript@5.9.3)(vite@5.4.21(@types/node@24.9.1))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,7 +34,6 @@ catalog:
   '@storybook/addon-a11y': ^8.3.5
   '@storybook/addon-essentials': ^8.3.5
   '@storybook/addon-docs': ^8.3.5
-  '@storybook/react': ^8.3.5
   '@storybook/react-vite': ^8.3.5
   '@storybook/test': ^8.3.5
   '@storybook/test-runner': ^0.23.0


### PR DESCRIPTION
## Summary
- remove the direct @storybook/react devDependency from the repo root and Storybook app packages
- update the pnpm workspace catalog and lockfile so only @storybook/react-vite is advertised

## Testing
- pnpm lint
- pnpm test --filter storybook... *(fails: @dynui/core test cannot locate packages/core/vitest.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ff7a1e041883249142030b6bf53f97