### PR TITLE
Add Storybook interactions addon to workspace catalog

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,9 +21,6 @@ catalogs:
     '@storybook/addon-essentials':
       specifier: ^8.3.5
       version: 8.6.14
-    '@storybook/addon-interactions':
-      specifier: ^8.3.5
-      version: 8.6.14
     '@storybook/react-vite':
       specifier: ^8.3.5
       version: 8.6.14
@@ -120,9 +117,6 @@ importers:
       '@storybook/addon-essentials':
         specifier: 'catalog:'
         version: 8.6.14(@types/react@18.3.26)(storybook@8.6.14(prettier@3.6.2))
-      '@storybook/addon-interactions':
-        specifier: 'catalog:'
-        version: 8.6.14
       '@storybook/react-vite':
         specifier: 'catalog:'
         version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.6.2)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.52.5)(storybook@8.6.14(prettier@3.6.2))(typescript@5.9.3)(vite@5.4.21(@types/node@24.9.1))


### PR DESCRIPTION
## Summary
- add the @storybook/addon-interactions package to the pnpm workspace catalog so the catalog resolver can populate the lockfile
- revert the manual @storybook/addon-interactions lockfile edits so pnpm can regenerate the entry from the catalog source

## Testing
- pnpm install --no-frozen-lockfile --lockfile-only *(fails: registry returns 403 Forbidden)*
- pnpm install --frozen-lockfile *(fails: registry returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6902bc78d0708324a54864c92d2d34f5